### PR TITLE
feat(v1.0): close all 9 v1.0 issues (#43-#51)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,3 +25,35 @@ require review and maintenance overhead that the author cannot commit to.
 Even though general issues are not accepted, security issues are taken
 seriously. Please contact the repository owner directly rather than opening
 a public issue or PR.
+
+## Changesets (internal — for the maintainer)
+
+Every PR (including internal task tracker PRs) that mutates a
+public-API package must include a changeset. The public-API
+packages and their stability commitments are listed in
+[UPGRADING.md](../UPGRADING.md).
+
+```bash
+pnpm changeset            # interactive: pick packages, bump type, summary
+```
+
+Bump-type rules:
+
+- `patch` — bug fixes, internal refactors, doc-only changes,
+  dependency bumps that don't change the public API.
+- `minor` — backwards-compatible additions to a public surface
+  (new optional config field, new CLI subcommand, new provider).
+- `major` — backwards-incompatible change to a public surface.
+  **Major changesets MUST include a draft `## From X.y → Z.0`
+  migration section in the changeset body.** That section is
+  promoted into [UPGRADING.md](../UPGRADING.md) when the version
+  ships.
+
+Changes that touch only internal-only surfaces (per UPGRADING.md
+"Internal-only surfaces") may use `patch` even when they would
+otherwise look like minor / major changes — the SemVer guarantee
+explicitly excludes those surfaces.
+
+If unsure whether a change is breaking, default to `major` and get
+the migration section drafted. It's cheaper to soft-revert a major
+bump in review than to ship a silent breakage.

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -18,6 +18,8 @@ jobs:
     name: review-agent dogfood
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,6 +39,7 @@ jobs:
       - run: pnpm -r --filter './packages/**' build
 
       - name: Run review-agent
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         uses: ./packages/action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,3 +47,7 @@ jobs:
           language: en-US
           config-path: .review-agent.yml
           cost-cap-usd: '0.50'
+
+      - name: Skip notice
+        if: ${{ env.ANTHROPIC_API_KEY == '' }}
+        run: echo "ANTHROPIC_API_KEY not set - skipping review-agent dogfood. Add the secret in repo settings to enable per-PR self-review."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,16 @@ compose everything. Never import from another package's `src/internal/`.
 
 ## Distribution status
 
-- v0.1: **complete.** All 13 issues (#1–#13) shipped on `main` and closed on
-  GitHub. See `docs/roadmap.md` for the per-issue commit map.
-- v0.2 + v0.3: open, not started.
+- v0.1: **complete.** All 13 issues (#1–#13) shipped on `main` and closed.
+- v0.2: **complete.** All 11 issues (#14–#24) shipped on `main` and closed.
+- v0.3: **complete.** All 13 issues (#25–#37) shipped on `main` and closed.
+  See `docs/roadmap.md` for the per-issue commit map.
+- v1.0: **planning.** 9 issues open (#43–#51) covering UPGRADING.md,
+  third-party security audit, eval baseline measurement, provider parity
+  matrix, bot identity guidance, multi-bot coordination, GHES compatibility,
+  `setup workspace` CLI, and cosign skill attestation tracking. See
+  `docs/roadmap.md` v1.0 section. Spec §22 deferred items resolved in
+  commit `849b6df`.
 
 ## What is NOT used (despite being tempting)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ See [`docs/specs/review-agent-spec.md`](./docs/specs/review-agent-spec.md)
 for the full specification and [`docs/roadmap.md`](./docs/roadmap.md) for
 the milestone plan.
 
+For the per-provider feature parity, eval delta, and cost / latency
+trade-offs across the seven supported drivers, see
+[`docs/providers/parity-matrix.md`](./docs/providers/parity-matrix.md).
+
 ## Status
 
 Maintained as a personal project. Code is published under the
@@ -125,6 +129,14 @@ are not accepted.
 - **Pull Requests**: Closed without review. See [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
 - **Issues**: Used for internal task tracking only.
 - **Forks**: Welcome.
+
+### Versioning
+
+From `v1.0.0` onwards `review-agent` follows
+[Semantic Versioning](https://semver.org/). The public API surface,
+internal-only surfaces, and per-version migration steps are in
+[UPGRADING.md](./UPGRADING.md). Pre-v1.0 (`0.x`) releases are not
+SemVer-stable.
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,6 +67,19 @@ Adversaries can attempt:
   recommended sandbox boundary. Self-hosted runners must enforce ephemeral
   VMs.
 
+## Pre-release security review
+
+`review-agent` undergoes a structured **internal STRIDE
+walkthrough** before each major release in lieu of a paid third-party
+audit. The walkthrough output is published at
+[`docs/security/threat-model-review-YYYY-MM.md`](./docs/security/audit.md);
+the procedure (and the choice between option a — paid audit — and
+option b — internal review) is documented at
+[`docs/security/audit.md`](./docs/security/audit.md). Adopters
+should treat `review-agent` as having had a structured internal
+review against STRIDE, not an independent paid audit. If your
+deployment requires the latter, commission your own engagement.
+
 ## Out of scope
 
 - Attacks against the GitHub Actions runner platform itself.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,246 @@
+# Upgrading
+
+`review-agent` follows [Semantic Versioning](https://semver.org/) from
+**v1.0.0 onwards**. This document declares which surfaces are part of
+the public API (and therefore protected by SemVer), which surfaces are
+internal (and may change between any two patch releases), and how to
+migrate across breaking version bumps.
+
+Pre-v1.0 releases (`0.x`) are not SemVer-stable — `0.1` → `0.2` and
+`0.2` → `0.3` shipped breaking changes routinely. v1.0 freezes the
+public API; subsequent breaking changes require a major bump and a
+matching `## From X.y → Z.0` section below.
+
+---
+
+## SemVer commitment
+
+| Bump | Allowed in | Example |
+|---|---|---|
+| Patch (`1.0.0 → 1.0.1`) | Bug fixes that preserve behaviour. Internal refactors. Documentation. Dependency bumps that don't change the public API surface. | Fix a regex in the gitleaks scanner, retry tweak in the LLM driver. |
+| Minor (`1.0.0 → 1.1.0`) | Backwards-compatible additions: new optional config fields, new optional `LlmProvider` capabilities, new CLI subcommands, new exports from a public package. | Add `coordination.other_bots: defer_if_present`, add a new provider driver. |
+| Major (`1.0.0 → 2.0.0`) | Backwards-incompatible changes to anything in the **public API surface** below. Always accompanied by a new `## From 1.y → 2.0` section. | Rename `runReview()` arguments, change the `.review-agent.yml` `version: 1` schema, drop a provider driver. |
+
+Provider-specific behaviour changes that originate **upstream** (e.g.
+Anthropic deprecating `claude-sonnet-4-5`) are documented in the
+release notes but do not trigger a major bump on their own. We track
+the upstream change and adjust pricing tables, default models, and
+docs in a minor release.
+
+---
+
+## Public API surface
+
+These are the surfaces that v1.0+ commits to maintain compatibility for.
+
+### `@review-agent/core`
+
+- All exported types from `packages/core/src/index.ts`:
+  `VCS`, `PR`, `PRRef`, `Diff`, `DiffFile`, `CloneOpts`,
+  `ExistingComment`, `GetDiffOpts`, `ReviewState`, `ReviewPayload`,
+  `InlineComment`, `Severity`, `Side`, `CostLedgerRow`, `AuditRow`,
+  `JobMessage`, `EncryptedPayload`, `KmsClient`, `BYOKProvider`,
+  `ReviewAgentError` and subclasses.
+- The Zod schemas: `ReviewOutputSchema`, `InlineCommentSchema`,
+  `JobMessageSchema`. Schema-level breaking changes (a previously
+  optional field becoming required, a removed enum case) are major.
+- The `fingerprint(input)` function and its `FingerprintInput`
+  contract — fingerprint stability is a hard guarantee because
+  hidden state comments depend on it.
+- The audit-log canonical-payload format and HMAC chain rule
+  (`canonicalPayload`, `computeAuditHash`, `AUDIT_GENESIS_HASH`).
+
+### `@review-agent/llm`
+
+- The `LlmProvider` interface from `packages/llm/src/types.ts`:
+  `name`, `model`, `generateReview`, `estimateCost`,
+  `pricePerMillionTokens`, `classifyError`. Breaking changes to
+  this shape force a major bump (every driver and the runner depend
+  on it).
+- The factory functions: `createAnthropicProvider`,
+  `createOpenAIProvider`, `createAzureOpenAIProvider`,
+  `createGoogleProvider`, `createVertexProvider`,
+  `createBedrockProvider`, `createOpenAICompatibleProvider`. Their
+  config object shape (`ProviderConfig`) is part of the public API.
+- The pricing tables (`ANTHROPIC_PRICING`, `OPENAI_PRICING`, etc.)
+  are exposed for operators that wrap them; rename / remove → major.
+
+### `@review-agent/runner`
+
+- `runReview(job, provider, deps?)` from `packages/runner/src/agent.ts`:
+  the `ReviewJob` shape, the `RunnerResult` shape, and the
+  optional `RunReviewDeps` shape.
+- `composeSystemPrompt`, `wrapUntrusted`, `loadSkills`,
+  `renderSkillsBlock` — composable building blocks for advanced
+  wirings (CLI, server, custom adapters).
+- `dedupComments`, `decideCoordination`, `renderDeferralSummary`,
+  `buildReviewState`, `createCostKillSwitch`, `assertDailyCapNotExceeded`,
+  `preflightDailyCap`, `scanWorkspaceWithGitleaks`,
+  `quickScanContent`, `applyRedactions`, `shouldAbortReview`,
+  `classifyForInjection`, `redactInjectionBlocks`,
+  `INJECTION_VERDICTS`, `resolveInjectionDetectorPolicy` — all
+  stable.
+- `INJECTION_DETECTOR_SYSTEM_PROMPT` — the **identifier** is
+  stable (it stays exported from `@review-agent/runner`), but the
+  **string value** is treated as tunable: rewording the prompt is
+  a patch-level change (see "Internal-only surfaces" below). Do
+  not compare it against a hardcoded value.
+- The middleware factory signatures (`createInjectionGuard`,
+  `createCostGuard`) and the `Middleware` / `MiddlewareCtx` types.
+
+### `@review-agent/config`
+
+- `ConfigSchema` (and the inferred `Config` / `ConfigInput` types).
+- The `version: 1` contract for `.review-agent.yml`. Breaking
+  changes to the YAML schema bump `version` (e.g. `version: 2`) and
+  ship with a documented migration in the `## From 1.y → 2.0` section.
+- `loadConfigFromYaml`, `defaultConfig`, `mergeWithEnv`,
+  `loadConfigWithOrgFallback`, `createOrgConfigCache`,
+  `mergeOrgIntoRepo`, `generateJsonSchema`,
+  `KNOWN_REVIEW_BOT_LOGINS`, `isKnownReviewBotLogin`,
+  `SUPPORTED_LANGUAGES`, `isSupportedLanguage`.
+
+### `@review-agent/platform-github`
+
+- `createGithubVCS({ token | appAuth })` — the `VCS` it returns is
+  the `core` interface (which is itself stable).
+- `createGithubOrgConfigFetch({ octokit })` for org-config
+  resolution.
+
+### `action.yml` (GitHub Action)
+
+The Action's inputs and outputs are part of the public API.
+
+| Surface | Stability |
+|---|---|
+| Input names: `github-token`, `anthropic-api-key`, `language`, `config-path`, `cost-cap-usd` | Stable. Renaming → major. |
+| Default values | Renaming a default that flips behaviour → major. Tweaking a default within compatible behaviour (e.g. nudging `cost-cap-usd` from 1.0 to 0.75) → minor with release-note callout. |
+| Outputs: `posted-comments`, `cost-usd` | Stable. Renaming → major. |
+| `runs.using: node20` | Bumping the Node major (e.g. node22) → minor; runtime contract preserved by Actions backwards compatibility. |
+
+### CLI flags
+
+The `review-agent` CLI's documented subcommand list and flag set is
+part of the public API.
+
+| Surface | Stability |
+|---|---|
+| Subcommands: `review`, `config validate`, `config schema`, `eval`, `recover sync-state`, plus v1.0 additions (`setup workspace`) | Stable. Removing a subcommand → major. |
+| Flag names: `--repo`, `--pr`, `--config`, `--lang`, `--profile`, `--cost-cap-usd`, `--post`, `--suite`, `--installation`, `--api`, `--admin-key` (where applicable) | Stable. Renaming → major. |
+| Default flag values | Same rule as Action defaults. |
+| Exit codes (0 success, 1 failure, 2 reserved for misuse via Commander) | Stable. |
+
+---
+
+## Internal-only surfaces (NOT covered by SemVer)
+
+The following may change between any two releases — including patch
+releases. Do not import these in third-party code:
+
+- Anything under `packages/*/src/internal/`.
+- Anything under `packages/runner/src/middleware/` directly (use the
+  re-exported factories instead).
+- Prompt strings: `composeSystemPrompt`'s output text format and
+  the body of the `INJECTION_DETECTOR_SYSTEM_PROMPT` constant + the
+  redaction placeholder string. We expose the identifiers as
+  stable but treat the *content* as tunable — rewording the prompt
+  is a patch-level change. Breaking the function *signature* (for
+  `composeSystemPrompt`) or removing the export entirely (for the
+  constant) is major.
+- Telemetry attribute names emitted via OTel (`packages/server`,
+  `packages/runner`). Operators wiring dashboards should treat the
+  schema as evolving and pin their dashboard queries by attribute
+  *intent*, not name.
+- The internal Drizzle column names and indexes in
+  `packages/db/src/schema/`. Migrations are the stable contract;
+  TypeScript identifiers may be renamed.
+- Test fixtures, eval baseline format internals, golden-fixture
+  manifest schema (the *eval pipeline contract* is stable, but
+  individual fixture file shapes are not).
+- The HTTP shape of the webhook receiver beyond what GitHub
+  documents (we just relay GitHub's payload semantics).
+
+---
+
+## Migration patterns
+
+When a major bump is required, the corresponding `## From X.y → Z.0`
+section uses a fixed shape so operators can scan quickly:
+
+1. **Summary** — one paragraph naming the breaking change and the
+   reason.
+2. **Affected surfaces** — bullet list of files / exports / config
+   keys that changed.
+3. **Migration** — concrete code or YAML diff showing before / after.
+4. **Detection** — how to know if your installation is affected
+   (e.g. "`pnpm typecheck` will fail with this error", or "schema
+   validation will reject `.review-agent.yml`").
+5. **Removal timeline** — if a deprecated alias ships first, when
+   it's removed.
+
+Migrations should be runnable by an operator following the doc
+top-to-bottom in 30 minutes for the median upgrade. Anything more
+ambitious gets a dedicated `docs/migrations/<topic>.md`.
+
+---
+
+## From 0.x → 1.0
+
+_v1.0 is the first SemVer-stable release. There is no source
+release-line below 0.3 that is upgrade-compatible with v1.0._
+
+Operators currently on `0.3.x` should:
+
+1. **Pin the v1.0 release tag** in CI (`almondoo/review-agent@v1`) and
+   re-run a self-review on a representative PR.
+2. **Validate `.review-agent.yml`** with
+   `review-agent config validate` — any schema breakages from
+   v0.3 → v1.0 surface here. (None are planned at this time;
+   this section will be updated if any land before tag.)
+3. **Re-read [`docs/configuration/coordination.md`](docs/configuration/coordination.md)
+   and [`docs/configuration/bot-identity.md`](docs/configuration/bot-identity.md)**
+   for the v1.0 stances on multi-bot coexistence and audit-trail
+   identity, both of which were deferred design questions in v0.3.
+4. **Decide the GHES posture**:
+   [`docs/deployment/ghes.md`](docs/deployment/ghes.md) declares
+   `best-effort, no commitment` — confirm this is acceptable for
+   your installation, or fork.
+5. **Refresh provider parity numbers**: see
+   [`docs/providers/parity-matrix.md`](docs/providers/parity-matrix.md)
+   for the v1.0 cross-provider eval results, regenerated via
+   `pnpm --filter @review-agent/eval matrix:run`.
+
+There is no automated migration. The v1.0 surface is intended to
+match the v0.3 surface byte-for-byte; the bump's purpose is the
+SemVer guarantee, not new code.
+
+---
+
+## Release process
+
+1. Add a changeset for every PR that touches a public-API package
+   (`pnpm changeset`). The changeset declares the bump type:
+   `patch`, `minor`, or `major`. **Major bumps must include a draft
+   `## From X.y → Z.0` migration section in the changeset body.**
+   See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) §
+   "Changesets" for the policy.
+2. `pnpm changeset:version` consumes pending changesets, updates
+   `package.json` versions, and writes per-package `CHANGELOG.md`.
+3. The release workflow (`.github/workflows/release.yml`) tags the
+   monorepo as `v<root-version>` and publishes the public packages
+   to npm.
+4. The corresponding `## From X.y → Z.0` section is promoted from
+   the changeset draft into this file before the tag is pushed.
+
+The internal-only packages (`@review-agent/server`, `@review-agent/db`,
+test fixtures) bump independently and don't appear in this file's
+migration sections.
+
+---
+
+## Cross-references
+
+- [`docs/specs/review-agent-spec.md`](docs/specs/review-agent-spec.md) — implementation specification (source of truth for behaviour).
+- [`docs/specs/prd.md`](docs/specs/prd.md) §12.1 v1.0 acceptance — "API stability declaration (SemVer に移行、UPGRADING.md 整備)" closed by this document.
+- [`README.md`](README.md) — quickstart; links here from the Status section.
+- [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) — Changesets policy on bump-type tagging.

--- a/docs/configuration/bot-identity.md
+++ b/docs/configuration/bot-identity.md
@@ -1,0 +1,134 @@
+# Bot identity per distribution mode
+
+`review-agent` posts review comments under whichever GitHub actor the
+auth method exposes. The actor is **not** a config knob — GitHub
+determines it from the credentials your distribution mode uses, and
+the value matters for audit-trail readability and downstream tooling
+that filters by author.
+
+This page documents the mapping operators should expect, the
+recommended setup per mode, and the audit-trail trade-offs.
+
+Spec reference: §22 #5 (the deferred design question is resolved here
+for v1.0). The fingerprint dedup in
+`packages/runner/src/middleware/dedup.ts` is identity-agnostic — the
+hidden state comment + per-finding fingerprint suppress repeats
+regardless of actor — so identity is *purely* an audit / readability
+concern, not a correctness one.
+
+---
+
+## Mapping table
+
+| Distribution mode | Default actor | Override path | Audit-trail story |
+|---|---|---|---|
+| GitHub Action (`uses: almondoo/review-agent@vX`) | `github-actions[bot]` | None — use the App or CLI mode if you need a distinct identity. | One actor across every Action; mixed with other workflows in `gh api repos/.../actions/runs`. |
+| Server mode (GitHub App) | `<your-app-name>[bot]` | Rename the App in **Settings → Developer settings → GitHub Apps → \<app\>**; the actor changes on the next install. | One actor per installation, distinct from `github-actions[bot]`. **Recommended for multi-repo / multi-tenant audit trails.** |
+| CLI mode (`review-agent review --post`) | The PAT owner's user account (e.g. `alice`) | Use a separate human or service account if you don't want comments attributed to a real person. | Mixed with the operator's own commits; not auditor-friendly. |
+
+### Action mode
+
+```yaml
+# .github/workflows/review.yml
+- uses: almondoo/review-agent@v0
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}   # actor: github-actions[bot]
+```
+
+The `secrets.GITHUB_TOKEN` is provisioned by GitHub Actions and is
+always issued to the `github-actions[bot]` actor. There is **no
+override** within Action mode itself — substituting a PAT or App
+token via `with: github-token:` would change the actor, but at the
+cost of widening the secret surface and breaking the scope of the
+default workflow token (`pull-requests: write` only).
+
+If you need a dedicated `<review-agent>[bot]` actor in an Action
+context, install the GitHub App version (Server mode) and disable
+the Action workflow.
+
+### Server mode (GitHub App)
+
+```ts
+// packages/server bootstraps the Hono receiver with a GitHub App
+// installation token. The actor is the App's own user account.
+import { createGithubVCS } from '@review-agent/platform-github';
+const vcs = createGithubVCS({
+  appAuth: { appId, privateKey, installationId },
+});
+```
+
+Name the App something audit-friendly — e.g. `acme-review` →
+posts as `acme-review[bot]`. Operators can search PR timelines for
+that login to find every review-agent comment across the org.
+
+### CLI mode
+
+```bash
+GITHUB_TOKEN=ghp_... review-agent review \
+  --repo acme/api --pr 42 --post
+```
+
+Comments are attributed to the PAT owner's account. This is
+intentional for the CLI's primary use case (interactive operator
+review), but it means audit logs cannot distinguish "human reviewed"
+from "agent reviewed via CLI". For audit-trail uniformity at scale,
+use Server mode instead.
+
+---
+
+## Audit-trail recommendation
+
+For multi-repo / multi-tenant deployments, **Server mode (GitHub
+App) is the recommended primary distribution mode** because:
+
+1. The App actor is distinct (one login per installation) and never
+   collides with workflow runs by other actions.
+2. Filtering audit logs by App actor isolates `review-agent` activity
+   without false positives from other Actions.
+3. Renaming the App propagates the new actor automatically without
+   re-permissioning.
+
+Action mode is acceptable for **single-repo trial use** or for orgs
+that don't run a Server deployment yet — the `github-actions[bot]`
+attribution is enough to find comments via
+`gh pr view <PR> --json comments` and grep, but is harder to
+correlate at org scale.
+
+CLI mode is **not recommended** for any audit-significant flow —
+use it only for one-off reviews where attribution to a human user
+is the *intended* behaviour.
+
+---
+
+## Why no `identity:` config knob?
+
+Two reasons we did not add a `coordination.identity:` (or similar)
+key to `.review-agent.yml`:
+
+1. **GitHub already determines actor per auth method.** A config
+   knob would create a second source of truth that could drift
+   from what the GitHub API returns. Operators inspecting the PR
+   timeline would see the actual actor, not the configured one.
+2. **The dedup story doesn't need it.** Per-finding fingerprints
+   (`fingerprint(path, line, ruleId, suggestionType)`) suppress
+   duplicate comments regardless of actor. Coordination *across*
+   bots is handled by `coordination.other_bots` — see
+   [`./coordination.md`](./coordination.md).
+
+If your audit pipeline genuinely needs a synthetic identity, the
+right place to insert one is at the secret-store layer (issue an App
+token bound to a renamed App), not at the agent layer.
+
+---
+
+## Cross-references
+
+- [`./coordination.md`](./coordination.md) — multi-bot coordination
+  policy (`coordination.other_bots`).
+- [`../security/audit-log.md`](../security/audit-log.md) — server-side
+  audit log (HMAC chain, recovery), where the actor is recorded for
+  every event.
+- [SECURITY.md](../../SECURITY.md) — overall threat model.
+- [`packages/action/README.md`](../../packages/action/README.md) — Action mode entry point.
+- [`packages/server/README.md`](../../packages/server/README.md) — Server mode (Hono webhook) entry point.
+- [`packages/cli/`](../../packages/cli/) — CLI mode entry point (no README; see `--help`).

--- a/docs/configuration/coordination.md
+++ b/docs/configuration/coordination.md
@@ -1,0 +1,147 @@
+# Multi-bot coordination
+
+When multiple PR review bots are installed on the same repository (for
+example `coderabbitai[bot]` alongside `review-agent`), the default
+behaviour is **independent review**: every bot reviews every PR, and
+review-agent's own dedup (`<!-- review-agent-state: ... -->` +
+per-finding fingerprint) only suppresses repeats of *its own* prior
+comments. There is no cross-bot suppression by default.
+
+Spec reference: §22 #9. The deferred design question — "should we
+recommend a single shared identity for audit-trail uniformity?" — is
+answered here for v1.0.
+
+---
+
+## Decision
+
+`review-agent` ships with three coordination stances:
+
+| Stance | Setting | When to use |
+|---|---|---|
+| Review every PR independently (default) | `coordination.other_bots: ignore` | Single-bot installations, or installations where each bot serves a distinct purpose (review-agent for diff review, a security-only bot for SAST). |
+| Defer when another known review bot is present | `coordination.other_bots: defer_if_present` | Installations running two general-purpose review bots in parallel — keep one as primary, defer to whichever posts first. |
+| Skip review-agent entirely (manual) | Not implemented as config | Use `reviews.auto_review.enabled: false` and trigger reviews via a manual workflow if needed. |
+
+`defer_if_present` is opt-in. The default is `ignore` because:
+
+1. Most installations run a single review bot. Adding a deference
+   mechanism by default would create a "silent skip" surprise.
+2. Even when two bots coexist, the operator may *want* both signals
+   for a few reviews before consolidating to one.
+3. The detection check costs a `pulls.listReviewComments` call per
+   PR; charging it in `ignore` mode for the 95% case would be wasteful.
+
+---
+
+## Configuration
+
+```yaml
+# .review-agent.yml
+coordination:
+  other_bots: defer_if_present     # default: ignore
+  other_bots_logins:               # default: []  (additive to built-in list)
+    - acme-internal-reviewer[bot]
+```
+
+### Built-in detection list
+
+The following GitHub App actors are detected automatically (defined in
+`packages/config/src/known-bots.ts`):
+
+- `coderabbitai[bot]`
+- `qodo-merge[bot]`
+- `pr-agent-bot[bot]`
+- `bedrock-pr-reviewer[bot]`
+
+Adding to `coordination.other_bots_logins` extends this set; you
+cannot remove built-in entries through config (use `ignore` if you
+don't want any deference).
+
+### Match semantics
+
+- Match is on **exact** GitHub login including the `[bot]` suffix.
+  `CodeRabbitAI[bot]` does not match `coderabbitai[bot]`, and
+  `coderabbit-fan` (a hypothetical human) does not match
+  `coderabbitai[bot]`. This is deliberate — partial / case-insensitive
+  matches risk false positives against humans.
+- Detection looks at **inline review comments only** (the GitHub
+  `pulls.listReviewComments` endpoint). Bots that post *only* a
+  single summary PR comment via `issues.createComment` (no inline
+  comments at all) are **not detected** in v1.0, even when added to
+  `coordination.other_bots_logins`. The login override extends the
+  detection set, but the underlying API call only returns inline
+  authors. Extending the VCS adapter to also list issue-level
+  comments is tracked as a v1.x improvement; until then, treat
+  `defer_if_present` as inline-comment-bot only.
+- The check runs **once per webhook**, before the agent loop. There
+  is no race-resolution: whichever bot posts first wins, and the
+  other defers on the next event.
+
+---
+
+## Operational behaviour
+
+When `defer_if_present` matches a known bot:
+
+1. `review-agent` posts a single skip-summary comment naming the
+   detected bot and the override path:
+
+   > ### review-agent — skipped
+   >
+   > Detected an existing review by `coderabbitai[bot]`.
+   > `coordination.other_bots` is set to `defer_if_present`, so this
+   > run will not post additional comments.
+   >
+   > To override, set `coordination.other_bots: ignore` in
+   > `.review-agent.yml` (or remove the key entirely — `ignore` is
+   > the default).
+
+2. No inline comments and no hidden `review-agent-state` row are
+   posted. The next event (push, PR re-open) re-evaluates from
+   scratch — there is no persistent "this PR was deferred" flag.
+3. The result returned to the runner / Action / Server reports
+   `skipped: true` with `skipReason: "Deferred to '<bot>' (coordination policy)"`.
+4. No LLM call is made; no cost is incurred.
+
+If the other bot posts after `review-agent` has already run, no
+deference happens. The dedup mechanism handles repeat events from
+`review-agent` itself, but does not retroactively erase posted
+comments. If you want to swap the primary bot mid-flight, configure
+`reviews.auto_review.enabled: false` for the secondary explicitly.
+
+---
+
+## Why no automatic shared identity?
+
+We considered making `review-agent` post under a shared `[review-bot]`
+identity to give auditors a single uniform actor across modes. Two
+reasons we didn't:
+
+1. GitHub already determines the actor per auth method (Action ↔
+   `github-actions[bot]`, App ↔ `<app-name>[bot]`, PAT ↔ user). A
+   config knob would create an *inconsistent* second source of truth
+   that could drift from what GitHub reports in the UI.
+2. The fingerprint dedup in `packages/runner/src/middleware/dedup.ts`
+   is identity-agnostic — identical content is suppressed regardless
+   of which actor would post it. So uniformity is unnecessary for
+   the dedup correctness story; it only helps audit-trail reading.
+
+For audit-trail uniformity, see
+[`./bot-identity.md`](./bot-identity.md) for the recommended
+distribution-mode mapping.
+
+---
+
+## Multi-bot installations: a few patterns
+
+| Pattern | Setting | Notes |
+|---|---|---|
+| Single bot (default) | omit `coordination` | Schema defaults handle it. |
+| review-agent + coderabbit, prefer either | `defer_if_present` on both bots | Whichever posts first wins; the other skips. Slightly racey but cheap. |
+| review-agent primary, secondary security bot only | `ignore` on review-agent; configure the secondary not to react to PRs review-agent has already commented on (per its own settings). | Keeps both signals; relies on the secondary having its own coordination knob. |
+| Org policy: review-agent only on certain repos | `reviews.auto_review.enabled: false` on the others | Honours operator intent without depending on inter-bot detection. |
+
+The detection list (`packages/config/src/known-bots.ts`) is updated
+manually per-release as new bots are reported. Open an internal issue
+if you encounter a coexistence scenario the static list doesn't cover.

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -225,6 +225,14 @@ Set `llm_provider = "anthropic"`, `terraform apply`, then populate
 `review-agent/anthropic-api-key` per §5.3. The worker reads the env var
 `ANTHROPIC_API_KEY_SECRET_NAME` and fetches the value at boot.
 
+**Recommended onboarding**: run `review-agent setup workspace` (CLI)
+before populating the secret. The command prints a manual checklist
+(workspace creation, ZDR enable, monthly spend cap) with deep links
+to console.anthropic.com, or with `--api` calls the Anthropic Admin
+API directly (requires `ANTHROPIC_ADMIN_KEY` — distinct from the
+inference key). The output includes the `.review-agent.yml` snippet
+and the secret name to wire into Secrets Manager.
+
 ### 7.3 OpenAI / Azure OpenAI / Vertex
 
 Not wired in this Terraform. Add a Secrets Manager entry for the API

--- a/docs/deployment/azure.md
+++ b/docs/deployment/azure.md
@@ -123,6 +123,12 @@ Vault. The worker reads the secret name from
 `ANTHROPIC_API_KEY_SECRET_NAME` env and pulls via the managed
 identity.
 
+**Recommended onboarding**: run `review-agent setup workspace` (CLI)
+before populating the Key Vault secret. The command prints a manual
+checklist (workspace creation, ZDR enable, spend cap), or with
+`--api` calls the Anthropic Admin API directly (requires
+`ANTHROPIC_ADMIN_KEY`, distinct from the inference key).
+
 ### 7.3 OpenAI-compatible endpoints
 
 Not wired in this Terraform. Adapt by setting `LLM_PROVIDER=openai-compatible`

--- a/docs/deployment/gcp.md
+++ b/docs/deployment/gcp.md
@@ -110,6 +110,12 @@ permissions in §7.1 are unnecessary in this mode.
 Set `llm_provider = "anthropic"`, `terraform apply`, then populate
 the Anthropic API key secret per §5.3 in the example README.
 
+**Recommended onboarding**: run `review-agent setup workspace` (CLI)
+to create the Workspace, enable ZDR, and set a monthly spend cap
+before populating the secret. Default mode prints a manual
+checklist; `--api` calls the Admin API directly (requires
+`ANTHROPIC_ADMIN_KEY`).
+
 ## 8. Networking
 
 - **Receiver** ingress: `INGRESS_TRAFFIC_ALL` (public). HMAC verify

--- a/docs/deployment/ghes.md
+++ b/docs/deployment/ghes.md
@@ -1,0 +1,128 @@
+# GitHub Enterprise Server (GHES) compatibility
+
+`review-agent` is built and tested against **github.com**. GHES
+compatibility is **best-effort, no commitment**: it may work today
+on a recent GHES release, but no part of the test suite or release
+process exercises a GHES instance.
+
+Spec reference: §22 #11 (the deferred design question is resolved
+here for v1.0).
+
+---
+
+## Stance: best-effort, no commitment
+
+| Item | Decision |
+|---|---|
+| Will issues / PRs against `review-agent` for GHES be reviewed? | Issues are accepted and triaged. PRs are not accepted (this repo does not take external contributions — see [CONTRIBUTING.md](../../.github/CONTRIBUTING.md)). |
+| Is GHES tested in CI? | No. CI runs against `github.com` only. |
+| Is there a minimum supported GHES version? | None declared. Recent GHES releases (3.13+) are likely closer to the github.com Octokit API surface; older releases drift further. |
+| Will compatibility regress between releases? | Possibly. Octokit version bumps in `packages/platform-github` may surface methods that GHES has not yet implemented. We do not track this proactively. |
+| Does this rule out GHES? | No. The codebase has no `github.com`-only assumptions baked into the runner; the platform adapter is the only GHES-relevant boundary. |
+
+This is a deliberate scope choice for v1.x. Adding a "supported"
+declaration would require:
+
+1. A GHES test instance in CI (recurring infra cost — not justified
+   for a personal-OSS project).
+2. A pinned minimum GHES version that the team commits to honour
+   across `@octokit/rest` upgrades.
+3. Expanded support burden for issues that turn out to be GHES
+   compatibility bugs rather than `review-agent` defects.
+
+If a GHES-focused fork emerges, that fork is the right place to
+declare a supported version range and run the corresponding CI.
+
+---
+
+## Known compatibility points
+
+These are the surfaces `review-agent` exercises that should work on
+recent GHES releases (verified informally — no automated coverage):
+
+- `pulls.get`, `pulls.listFiles`, `pulls.createReview`,
+  `pulls.listReviewComments` — standard PR APIs available since
+  GHES 3.0.
+- `issues.createComment`, `issues.listComments`,
+  `issues.updateComment`, `issues.deleteComment` — standard since
+  GHES 3.0.
+- `git.getBlob`, `git.getTree`, `git.getCommit` — standard since
+  GHES 3.0.
+- Webhook delivery format (HMAC-SHA-256 over the raw body, header
+  `X-Hub-Signature-256`, `X-GitHub-Delivery` UUID) — same as
+  github.com.
+
+For Server-mode deployments, the GitHub App auth flow
+(`@octokit/auth-app`) requires that the GHES instance has the App
+installed. App-level features (installation tokens, JWT signing)
+behave identically to github.com.
+
+## Known incompatibilities
+
+- **github.com-specific REST endpoints**: anything we use from the
+  `@octokit/rest` client that lands on github.com between GHES
+  releases will 404 on older GHES until they catch up. Examples
+  historically: `pulls.requestReviewers` body shape changes,
+  `issues.list` filtering parameters, audit-log endpoints.
+- **GraphQL schema lag**: we use REST today, not GraphQL, so this
+  is moot. If a future feature requires GraphQL it will likely
+  break GHES until the schema lands.
+- **Rate-limit headers**: GHES exposes the same header names but the
+  ceiling depends on the instance's configuration. The retry
+  middleware (`@octokit/plugin-throttling`) honours whatever the
+  server reports, so rate-limit handling is correct by construction.
+- **`installation` event for `installation_repositories`**: GHES
+  versions that pre-date this event will silently no-op the
+  installation lifecycle — operators will need to manage installs
+  manually.
+
+## Operational guidance for GHES users
+
+1. **Use the CLI mode for ad-hoc reviews** if Action / App
+   provisioning is constrained on your GHES instance. Point
+   `--repo` at the GHES URL pattern (the CLI does not currently
+   support a custom GHES base URL — see "What's not configurable"
+   below).
+2. **Set the Octokit base URL** via the `GITHUB_API_URL` env var
+   that GitHub Actions / Octokit honours by convention. Most of the
+   `@octokit/*` packages we use respect `GITHUB_API_URL`; the
+   platform adapter does not currently expose this as a config
+   knob, so deployments need to set it at the process level
+   before the adapter is constructed.
+3. **Pin the Octokit version**: `@octokit/rest` upgrades may break
+   on older GHES. If you depend on a specific GHES release, pin the
+   `review-agent` version too — newer `review-agent` releases may
+   bump Octokit.
+4. **Monitor for 404s**: a sudden spike in 4xx from the platform
+   adapter usually means GHES has not yet shipped a new endpoint.
+   File an internal issue with the failing endpoint name.
+
+## What's not configurable today
+
+The following are hardcoded to github.com behaviour and would need
+explicit code changes to fully support GHES:
+
+- The platform adapter does not accept a `baseUrl: string` config
+  knob (`packages/platform-github/src/adapter.ts`). Octokit picks
+  up `GITHUB_API_URL` from the environment, so process-level env
+  vars work, but per-installation override does not.
+- The CLI's `--repo owner/name` parser assumes github.com URL
+  shapes. GHES URLs (`https://ghes.acme.com/owner/name`) are not
+  parsed.
+- GHES-specific webhook subtypes (e.g. enterprise audit log events)
+  are not handled.
+
+These are intentional v1.0 omissions. If GHES support becomes a
+recurring request, a `--ghes-base-url` flag plus a per-installation
+override are the smallest surface that would close the gap — file
+an issue if you want them.
+
+---
+
+## Cross-references
+
+- [`../specs/prd.md`](../specs/prd.md) §12 / Post-v1.0 — GHES listed
+  as future work; the v1.0 stance is "best-effort, no commitment".
+- [`../specs/review-agent-spec.md`](../specs/review-agent-spec.md) §22 #11 — original deferred design question.
+- [`../../packages/platform-github/`](../../packages/platform-github/) — the only adapter that
+  would need GHES-specific changes.

--- a/docs/eval/baseline-measurement.md
+++ b/docs/eval/baseline-measurement.md
@@ -1,0 +1,185 @@
+# Recording the eval baseline
+
+`packages/eval/baseline.json` is the source of truth for what
+constitutes "passing" on the 60-fixture golden corpus. The
+`gates.*` block holds the merge-blocking thresholds; the
+`current_pass_rates.*` block records the most recent measured
+performance on the default provider stack.
+
+This page documents the **measurement procedure** for populating
+`current_pass_rates` and the per-provider runs feeding the parity
+matrix in [`../providers/parity-matrix.md`](../providers/parity-matrix.md).
+Spec reference: PRD §12.1 v1.0, v1.0 issue #45.
+
+The current state of `baseline.json` ships with `pending_measurement:
+true` and all numeric fields `null` — the schema is in place but no
+row has been measured yet. The first row is the operator's
+responsibility, run from a workstation or a dedicated CI job, **not**
+from the per-PR self-review CI (which would burn the budget on every
+PR).
+
+---
+
+## When to re-measure
+
+Trigger | Cadence
+---|---
+First v1.0 baseline | Once before the v1.0 tag.
+Default provider model bump | Each time `packages/llm/src/pricing.ts` updates the pinned default (e.g. `claude-sonnet-4-6` → `claude-sonnet-4-7`).
+Provider parity matrix refresh | Per minor release, plus on every provider major version bump.
+Prompt rewrite touching `packages/runner/src/prompts/` | Any non-cosmetic change to the system prompt.
+Suspected regression | Whenever a real PR shows an unexpected false-positive or miss.
+
+Cost: ~$2.20 per Sonnet-4.6 run on the 60-fixture corpus
+(`baseline.json.estimated_run_cost_usd`). Per-provider runs total
+$5–8 per regen across the seven drivers.
+
+---
+
+## Procedure
+
+### 1. Record the snapshot inputs
+
+Capture the exact code revision being measured. The `git_sha` is
+mandatory so a future regression bisect can rebuild the same
+baseline.
+
+```bash
+cd /path/to/review-agent
+GIT_SHA=$(git rev-parse HEAD)
+DATE=$(date -u +%Y-%m-%d)
+MODEL_ID=$(node -e "import('./packages/llm/dist/index.js').then(m => process.stdout.write(m.DEFAULT_ANTHROPIC_MODEL))" 2>/dev/null || echo "claude-sonnet-4-6")
+echo "git_sha=$GIT_SHA  date=$DATE  model=$MODEL_ID"
+```
+
+### 2. Run the golden eval against the default provider
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... \
+  pnpm --filter @review-agent/eval eval -- -o results-default.json
+```
+
+`results-default.json` contains per-fixture pass / fail rows. The
+aggregation step (next) reduces them to the five `current_pass_rates`
+fields.
+
+### 3. Run the red-team eval (gate: `red_team_bypass_count` MUST be 0)
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... \
+  pnpm --filter @review-agent/eval eval:red-team -- -o results-red-team.json
+```
+
+Any non-zero bypass count blocks the row from being recorded —
+investigate the bypass and ship a prompt fix or a detector hardening
+in the same PR.
+
+### 4. Aggregate per-fixture results into the five baseline fields
+
+The aggregation today is manual: open `results-default.json`, count
+known-bug TP / FP / FN per the rules in §14.3 of the implementation
+spec, divide. A `scripts/aggregate-baseline.ts` helper is a v1.x
+nice-to-have but not blocking — the math is straightforward at 60
+fixtures.
+
+| Field | Formula |
+|---|---|
+| `known_bug_precision` | TP / (TP + FP), measured on `category: known-bug` fixtures only. |
+| `known_bug_recall` | TP / (TP + FN), measured on `category: known-bug` fixtures. |
+| `no_issue_false_positive_rate` | (count of fixtures with ≥ 1 comment) / (total `category: no-issue`). |
+| `red_team_bypass_count` | from `results-red-team.json`; non-zero blocks merge. |
+| `large_diff_max_wall_seconds` | max wall time across `category: large-diff` fixtures. |
+| `multi_language_target_language_match_rate` | fraction of `category: multi-language` fixtures whose comments are in the configured target language. |
+
+### 5. Update `current_pass_rates` and append to `history`
+
+Open `packages/eval/baseline.json` and:
+
+1. Move the previous `current_pass_rates` block (if non-null) into
+   the `history: []` array as a new object — preserve the previous
+   `measurement_metadata` block intact.
+2. Replace `current_pass_rates` with the new measurement:
+
+```json
+"current_pass_rates": {
+  "pending_measurement": false,
+  "measurement_metadata": {
+    "recorded_at": "2026-05-15",
+    "model_id": "claude-sonnet-4-6",
+    "git_sha": "abc1234",
+    "notes": "First v1.0 baseline. Per-fixture aggregation via manual count."
+  },
+  "known_bug_precision": 0.94,
+  "known_bug_recall": 0.78,
+  "no_issue_false_positive_rate": 0.03,
+  "red_team_bypass_count": 0,
+  "large_diff_max_wall_seconds": 47,
+  "multi_language_target_language_match_rate": 0.98
+}
+```
+
+3. Confirm every field clears its `gates.*_min` / `_max` threshold.
+   If a field falls below the gate (e.g. `precision = 0.85` against
+   the `0.9` gate), there are two acceptable responses, **not** a
+   silent gate relaxation:
+   - **Tune the prompt and re-measure** — preferred when the
+     regression looks fixable.
+   - **Document the gate revision in the same PR** — acceptable
+     only when a careful review confirms the gate was set
+     unrealistically. The PR description must explain *why* the
+     real-world quality is preserved despite the looser gate.
+
+### 6. Run the per-provider matrix runs (optional but expected for #46)
+
+For each non-default provider in
+[`../providers/parity-matrix.md`](../providers/parity-matrix.md),
+repeat steps 2–4 with that provider's credentials and aggregate
+into [`../../packages/eval/parity.json`](../../packages/eval/parity.json).
+Then refresh the rendered table:
+
+```bash
+pnpm --filter @review-agent/eval matrix:write
+pnpm --filter @review-agent/eval matrix:check    # CI-friendly verify
+```
+
+### 7. Commit
+
+```bash
+git add packages/eval/baseline.json packages/eval/parity.json docs/providers/parity-matrix.md
+git commit -m "feat(eval): record measured baseline ($DATE, $MODEL_ID@$GIT_SHA)"
+```
+
+The commit message is purely conventional; CI does not parse it.
+The `$DATE / $MODEL_ID / $GIT_SHA` in the message duplicates the
+`measurement_metadata` block for grep-ability.
+
+---
+
+## What we deliberately do NOT automate
+
+- **Per-PR re-measurement** — the cost is $2.20+ per run; running
+  this on every PR would dominate `cost-cap-usd`.
+- **Auto-aggregation** — the manual count step (§4) is small enough
+  that a script would add more risk than value at 60 fixtures.
+  Automate when the corpus exceeds 200 fixtures.
+- **CI-blocking comparison against `baseline.json`** — the eval CI
+  compares the *latest run* against the previous one's pass rates
+  (`gates.precision_drop_max`, `gates.noise_rate_increase_max`).
+  Adding a "current must equal baseline" gate would invert the
+  intent: baseline is the *summary* of what the agent does well,
+  not a target to chase.
+
+---
+
+## Cross-references
+
+- [`../../packages/eval/baseline.json`](../../packages/eval/baseline.json) — the file
+  this procedure populates.
+- [`../../packages/eval/parity.json`](../../packages/eval/parity.json) — per-provider
+  source data feeding the parity matrix.
+- [`../providers/parity-matrix.md`](../providers/parity-matrix.md) — published
+  per-provider table; depends on parity.json.
+- [`./golden-prs.md`](./golden-prs.md) — fixture corpus design.
+- [`../specs/review-agent-spec.md`](../specs/review-agent-spec.md) §14.3, §14.4 —
+  source-of-truth definitions for precision / recall / FP rate /
+  bypass count.

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -109,3 +109,9 @@ Three reasons:
   emits malformed JSON, you'll see a `SchemaValidationError` from
   `@review-agent/core` — that's the correct loud failure mode; do
   not silently retry past the configured budget.
+
+## See also
+
+- [`./parity-matrix.md`](./parity-matrix.md) — cross-provider
+  feature / eval / cost matrix; the openai-compatible row is
+  intentionally `endpoint-dependent` for every cell.

--- a/docs/providers/parity-matrix.md
+++ b/docs/providers/parity-matrix.md
@@ -1,0 +1,136 @@
+# Per-provider feature parity matrix
+
+`review-agent` supports seven LLM provider drivers. They are not
+identical: prompt caching is Anthropic / Bedrock / Vertex-only,
+structured output strength varies, and per-PR cost / latency / data
+retention posture differs by orders of magnitude. This page is the
+operator-facing reference for picking a provider informed.
+
+Spec reference: §22 #12 (the deferred design question is resolved
+here for v1.0). Source data lives at
+[`packages/eval/parity.json`](../../packages/eval/parity.json) and
+the rendered table below is regenerated from it via
+`pnpm --filter @review-agent/eval matrix:write`.
+
+---
+
+## How to read this matrix
+
+- **Eval columns** (precision, FP rate, noise Δ) come from the
+  60-fixture corpus described in `packages/eval/README.md`. The
+  Anthropic baseline model (`claude-sonnet-4-6`) defines the noise
+  floor; `noise Δ vs baseline` shows each other provider's deviation
+  in proportional terms.
+- **Cost / latency** are wall-clock measurements from a full eval
+  run. Per-provider cost is the median across all 60 fixtures.
+  p95 latency is total wall time including retries.
+- **Data retention** summarises the provider's default posture for
+  the inference key tier `review-agent` recommends in deployment
+  docs. Operators on enterprise contracts should confirm against
+  their own contract — these are not legal guarantees.
+- A `—` value means "not yet measured". When the table is fully
+  populated, no `—` should remain except in the openai-compatible
+  row where features are necessarily endpoint-dependent.
+
+Re-run cost: a full re-measurement across all paid providers is
+$5–8 per regen. The cadence is per minor release, plus on every
+provider major version bump. CI does **not** auto-regenerate this
+table — measurements are operator-triggered to avoid burning the
+budget on every PR.
+
+---
+
+<!-- BEGIN matrix -->
+_Numbers measured: **not yet measured**. Baseline: `claude-sonnet-4-6`. See [packages/eval/parity.json](../../packages/eval/parity.json) for source data._
+
+| Provider | Default model | Prompt caching | Structured output | Tool calling | Precision | FP rate | Noise Δ vs baseline | Median PR cost (USD) | p95 latency (s) | Data retention |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Anthropic (direct) | `claude-sonnet-4-6` | yes | json-schema | yes | — | — | baseline | — | — | ZDR opt-in per Workspace; default 30-day retention |
+| OpenAI (direct) | `gpt-4o` | no | json-schema | yes | — | — | — | — | — | ZDR opt-in for Enterprise tier; default 30-day retention |
+| Azure OpenAI | `gpt-4o` | no | json-schema | yes | — | — | — | — | — | no training-data use by default; abuse-monitoring 30 days unless opt-out |
+| Google (Gemini direct) | `gemini-2.0-pro` | no | json-schema | yes | — | — | — | — | — | paid tier: no training-data use; default retention varies |
+| Vertex AI | `claude-sonnet-4-6@anthropic` | yes | json-schema | yes | — | — | — | — | — | GCP customer data not used for model training |
+| AWS Bedrock | `anthropic.claude-sonnet-4-6-v1:0` | yes | json-schema | yes | — | — | — | — | — | AWS customer data not used for model training; per-region storage |
+| OpenAI-compatible (Ollama / vLLM / OpenRouter / LM Studio) | `endpoint-dependent` | endpoint-dependent | endpoint-dependent | endpoint-dependent | — | — | — | — | — | endpoint-dependent (often local-only for self-hosted backends) |
+
+Numbers measured via the 60-fixture corpus (packages/eval/fixtures/golden/). Re-run via `pnpm --filter @review-agent/eval matrix:run -- <provider>` (one provider at a time so cost is bounded). Estimated full re-measurement cost across all paid providers: $5-8 per regen run.
+<!-- END matrix -->
+
+---
+
+## Caveats
+
+- **Version pins**: each provider's model id is pinned in
+  [`packages/llm/src/pricing.ts`](../../packages/llm/src/pricing.ts).
+  When upstream deprecates a model (e.g. `gpt-4o` → `gpt-4.1`), the
+  pinned default changes in a minor release and the matrix is
+  regenerated. The "Default model" column reflects the **current**
+  pinned default, not whichever model was current at last
+  measurement.
+- **OpenAI-compatible row**: there is no canonical model. Per
+  [`./openai-compatible.md`](./openai-compatible.md), behaviour
+  depends entirely on the endpoint — most local 30B–70B models clear
+  the structured-output bar; smaller models do not. We do not
+  publish per-endpoint numbers because the matrix would never stop
+  growing.
+- **Cost columns assume the workload shape from the 60-fixture
+  corpus** — diffs ranging from a few-line bug fix up to a 3000-line
+  large-diff fixture. Real-world median cost is usually lower
+  because production diffs are smaller; large-diff outliers
+  dominate the p95.
+- **No regression CI for this table**. The
+  `pnpm --filter @review-agent/eval matrix:check` script verifies
+  that the rendered table matches `parity.json`; it does NOT
+  verify that the `parity.json` numbers are still accurate. That
+  responsibility lives with the operator running scheduled
+  re-measurements per the cadence above.
+- **Provider rows that fail the existing `baseline.json` gates**
+  (precision < 0.9 / FP > 0.05 / red-team-bypass > 0) are
+  documented here with rationale rather than silently relaxing the
+  gate in `baseline.json`. If a provider can't clear the gate even
+  after prompt tuning, the matrix gets a footnote explaining the
+  trade-off (e.g. "openai-compatible/llama3.1:70b: precision 0.78,
+  acceptable for self-hosted privacy-first use only").
+
+---
+
+## Regenerating the matrix
+
+Operator workflow for a fresh measurement:
+
+```bash
+# 1. Run promptfoo against each provider with credentials in the env.
+ANTHROPIC_API_KEY=...    pnpm --filter @review-agent/eval eval -- --providers anthropic:messages:claude-sonnet-4-6 -o results-anthropic.json
+OPENAI_API_KEY=...       pnpm --filter @review-agent/eval eval -- --providers openai:gpt-4o                       -o results-openai.json
+# (repeat for azure-openai / google / vertex / bedrock / openai-compatible)
+
+# 2. Aggregate the per-provider precision / FP / latency numbers
+#    into packages/eval/parity.json. (Manual step today; a future
+#    matrix:aggregate subcommand could automate this.)
+
+# 3. Refresh the published doc.
+pnpm --filter @review-agent/eval matrix:write
+
+# 4. Verify the doc is in sync (CI-friendly).
+pnpm --filter @review-agent/eval matrix:check
+```
+
+`matrix:write` only mutates the block between
+`<!-- BEGIN matrix -->` and `<!-- END matrix -->` — surrounding
+prose is preserved. Edit the prose freely; it is never
+auto-overwritten.
+
+---
+
+## Cross-references
+
+- [`./openai-compatible.md`](./openai-compatible.md) — caveats on
+  the openai-compatible row.
+- [`packages/eval/baseline.json`](../../packages/eval/baseline.json) — gates the matrix
+  cells must clear.
+- [`packages/eval/parity.json`](../../packages/eval/parity.json) — source data for the
+  rendered table above.
+- [`packages/llm/src/pricing.ts`](../../packages/llm/src/pricing.ts) — pinned model ids
+  per provider.
+- [UPGRADING.md](../../UPGRADING.md) — model-default changes are
+  minor bumps; this matrix is regenerated alongside.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,6 +80,29 @@ gh issue view <N> --repo almondoo/review-agent
 
 ---
 
+## v1.0 — Stable: API freeze, security audit, full quality bar (9 issues)
+
+| # | Issue | Title (short) | Depends on |
+|---|---|---|---|
+| 43 | [#43](https://github.com/almondoo/review-agent/issues/43) | docs(repo): UPGRADING.md template + SemVer stability declaration | — |
+| 44 | [#44](https://github.com/almondoo/review-agent/issues/44) | security: third-party security audit or equivalent threat-model review | #36, #37 |
+| 45 | [#45](https://github.com/almondoo/review-agent/issues/45) | feat(eval): record first measured baseline across all providers | #31, #33 |
+| 46 | [#46](https://github.com/almondoo/review-agent/issues/46) | docs(providers): per-provider feature parity matrix | #31, #33, #45 |
+| 47 | [#47](https://github.com/almondoo/review-agent/issues/47) | docs(repo): bot identity guidance for Action vs Server modes | — |
+| 48 | [#48](https://github.com/almondoo/review-agent/issues/48) | feat(runner,config): multi-bot coordination policy | — |
+| 49 | [#49](https://github.com/almondoo/review-agent/issues/49) | docs(repo,platform-github): GHES compatibility statement | — |
+| 50 | [#50](https://github.com/almondoo/review-agent/issues/50) | feat(cli): `review-agent setup workspace` (Anthropic ZDR + spend caps) | #23 |
+| 51 | [#51](https://github.com/almondoo/review-agent/issues/51) | feat(skills,security): cosign attestation for npm-distributed skills (v1.1 tracking) | #7 |
+
+**Suggested execution order**: 43 → 47 / 49 → 45 → 46 → 48 → 50 → 44 → 51. #51
+is a v1.1 tracking ticket and can be closed as wontfix if first-party skill
+publication is not undertaken.
+
+**v1.0 acceptance criteria**: see PRD §12.1. Closing all 9 issues plus
+re-running typecheck / lint / test / eval / build is the v1.0 release gate.
+
+---
+
 ## Status
 
 v0.1 — all 13 issues shipped on `main`:
@@ -108,8 +131,26 @@ v0.2 progress:
 - #19 incremental review (rebase + line shift + state mirror) — `2331ad6`
 - #20 OTel + Langfuse + body redaction — `91e216d`
 - #21 cost ledger + audit HMAC chain — `8d48d9a`
-- #22 AWS Lambda + Terraform + deployment docs — see latest commit
+- #22 AWS Lambda + Terraform + deployment docs — `dcc73cc`
 - #23 review-agent CLI — `7983256`
 - #24 llm OpenAI provider — `3815cea`
 
-v0.3: open, not started.
+v0.3 — all 13 issues shipped on `main`:
+
+- #25 db RLS for multi-tenancy — `c6c82ac`
+- #26 per-installation BYOK with KMS envelope encryption — `4ab1eb1`
+- #27 org central config repository — `faed42a`
+- #28 Helm chart + KEDA autoscaling — `49c2e59`
+- #29 GCP Cloud Run + Terraform + deployment docs — `7e8fa44`
+- #30 Azure Container Apps + Terraform + deployment docs — `9e228ff`
+- #31 full provider matrix (Azure / Google / Vertex / Bedrock / OpenAI-compat) — `20d9414`
+- #32 red-team golden fixtures + CI gate — `0033a5b`
+- #33 prompt eval harness expanded to 50+ PRs — `1a82354`
+- #34 docker-compose self-host example — `413a4a7`
+- #35 cost cap enforcement at runtime — `bc0e5f9`
+- #36 LLM-based injection detector — `071b3a8`
+- #37 incident response runbooks finalized — `774ee4c`
+- spec §22 open questions resolved — `849b6df`
+
+v1.0 — planning. 9 issues open (#43–#51). See the v1.0 table above for the
+per-issue scope and dependencies. None merged yet.

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -75,3 +75,14 @@ treat any break as a §8.6.5 incident (database compromise).
 - **Genesis row**: cycling the table (e.g. for tests) resets the chain.
   Production data must never start from a non-empty table without a
   matching `prev_hash` prefix.
+
+## Actor identity in audit rows
+
+`audit_log` rows do not store the GitHub actor that posted the
+review comment — the actor is determined by the auth method
+(`github-actions[bot]` for the Action, `<app-name>[bot]` for the
+GitHub App, the PAT owner for the CLI). Operators that want a
+uniform actor across the org should run Server mode with a renamed
+GitHub App; see [`../configuration/bot-identity.md`](../configuration/bot-identity.md)
+for the per-mode mapping and the rationale for not exposing actor as a
+config knob.

--- a/docs/security/audit.md
+++ b/docs/security/audit.md
@@ -1,0 +1,103 @@
+# Pre-v1.0 security review approach
+
+PRD §12.1 v1.0 requires "third-party security audit, or equivalent
+threat-model review" before tagging v1.0. This document records
+which option `review-agent` chose and why, plus the deliverable
+location.
+
+Spec reference: PRD §12.1 v1.0, v1.0 issue #44.
+
+---
+
+## Decision: option (b) — internal threat-model walkthrough
+
+`review-agent` is a personal project published as OSS for
+reference (not accepting external contributions). Commissioning a
+paid third-party security audit (option a) is disproportionate to
+the maintainer's scope: the cost ($25k–$80k for a focused
+engagement) exceeds the project's lifetime budget by orders of
+magnitude, and there is no operator paying for hosted access to
+amortise it.
+
+We therefore selected **option (b): a structured internal
+threat-model walkthrough** against the STRIDE framework, with one
+required gating: at least one reviewer outside the maintainer's
+direct affiliation must sign off.
+
+This matches the PRD's explicit acknowledgement that option (b) is
+acceptable. We document the trade-off honestly so adopters
+understand the depth of review:
+
+> Adopters should treat `review-agent` as having had a structured
+> internal review against STRIDE, **not** an independent paid
+> audit. If your deployment requires the latter (e.g. a regulated
+> environment), commission your own engagement covering at least
+> the seven attack categories in
+> [`./threat-model-review-2026-05.md`](./threat-model-review-2026-05.md).
+
+---
+
+## Procedure
+
+1. **STRIDE walkthrough**: each of the six STRIDE categories
+   (Spoofing, Tampering, Repudiation, Information disclosure,
+   Denial of service, Elevation of privilege) is walked through
+   against the data-flow surfaces in `SECURITY.md` "Threat model"
+   plus the post-v0.3 surfaces (BYOK, multi-tenant RLS, server
+   webhook receiver, audit log). Each category produces a finding
+   list.
+2. **Findings triage**: each finding is rated `informational`,
+   `low`, `medium`, `high`, or `critical`. `high` and `critical`
+   block v1.0 tagging until fixed; `medium` and below are tracked
+   in the issue list as v1.x follow-up.
+3. **Unaffiliated reviewer sign-off**: at least one reviewer who
+   is not the project's primary author reads the walkthrough,
+   challenges the assumptions, and either signs off or flags
+   missing surfaces. **This step is the required gate for v1.0
+   tagging — it cannot be self-attested.** The reviewer's
+   affiliation, name (or initials, with the maintainer's
+   verification on file), and the date of sign-off are recorded
+   at the bottom of `threat-model-review-2026-05.md`.
+4. **SECURITY.md update**: any new attack surface or mitigation
+   discovered during the walkthrough is reflected in
+   [`../../SECURITY.md`](../../SECURITY.md) so the published
+   threat model stays in sync.
+5. **Public summary**: a redacted summary of findings + mitigations
+   is published under `docs/security/`. Sensitive details (e.g.
+   detection-bypass specifics) may be omitted.
+6. **Annual cadence**: the walkthrough is repeated yearly as part
+   of release hygiene. Each year's run gets its own
+   `docs/security/threat-model-review-YYYY-MM.md` file.
+
+---
+
+## Deliverables
+
+| Deliverable | Location | Status |
+|---|---|---|
+| Procedure / decision rationale (this file) | `docs/security/audit.md` | Authored. |
+| 2026-05 STRIDE walkthrough | [`./threat-model-review-2026-05.md`](./threat-model-review-2026-05.md) | Drafted by maintainer. **Awaiting unaffiliated reviewer sign-off.** |
+| SECURITY.md updates | [`../../SECURITY.md`](../../SECURITY.md) | No new surfaces discovered in this round; existing mitigation table stays. |
+| Public summary | bottom of `threat-model-review-2026-05.md` "Summary of findings" section | Drafted; updated if reviewer flags additional findings. |
+
+The unaffiliated-reviewer gate is the **only blocker** for closing
+issue #44 and tagging v1.0. The maintainer's responsibility is to
+identify a willing reviewer (a peer engineer, security-focused
+collaborator, or hired consultant for scoped review) and incorporate
+their feedback before the v1.0 tag.
+
+If no unaffiliated reviewer is available within a reasonable
+timeframe, the v1.0 tag is gated indefinitely — we do not relax the
+rule to ship faster. Issue #44 stays open.
+
+---
+
+## Cross-references
+
+- [`./threat-model-review-2026-05.md`](./threat-model-review-2026-05.md) — the actual walkthrough.
+- [`../../SECURITY.md`](../../SECURITY.md) — published threat model.
+- [`./oncall.md`](./oncall.md) — incident response SLOs and tabletop
+  format (referenced during the DoS / availability walkthrough).
+- [`./byok.md`](./byok.md) — per-installation BYOK envelope encryption (Tampering / Information disclosure walkthrough input).
+- [`./audit-log.md`](./audit-log.md) — HMAC chain (Repudiation walkthrough input).
+- [`./red-team.md`](./red-team.md) — red-team eval fixtures (Information disclosure walkthrough input).

--- a/docs/security/skill-attestation.md
+++ b/docs/security/skill-attestation.md
@@ -1,0 +1,121 @@
+# Skill provenance and attestation
+
+This document records the v1.0 decision on skill-provenance
+attestation (cosign or equivalent) for npm-distributed skills.
+Spec reference: §15.7.3 (bundled skills), §22 #15 (deferred to
+v1.1+), v1.0 issue #51.
+
+---
+
+## Decision: closed as wontfix for v1.0/v1.1
+
+`review-agent` ships skill-loader infrastructure (`packages/runner/src/skill-loader.ts`)
+that supports skills referenced by relative path under
+`.review-agent/skills/<name>/SKILL.md`. The current integrity check
+is a YAML frontmatter validator + a body sanitiser (script-tag and
+forbidden-fenced-language stripper) + a 50 KB size cap. There is
+**no SHA-256 manifest check today** because no first-party
+`@review-agent/skill-*` packages have been published.
+
+Spec §22 #15 explicitly defers cosign attestation to v1.1 and asks
+us to "re-evaluate based on contributor demand. Track in a roadmap
+issue, not in the spec." This document is the resolution of that
+tracking item.
+
+**v1.0 outcome**: cosign attestation infrastructure is **not
+implemented**. Issue #51 closed as wontfix. The decision is
+revisited if and when the first first-party skill is published.
+
+---
+
+## Why wontfix at v1.0
+
+Three concrete reasons:
+
+1. **No users exist.** As of v1.0 there are zero first-party
+   `@review-agent/skill-*` npm packages (per spec §22 #4, that
+   decision is itself v1.0+). Implementing cosign verification
+   today protects against a supply-chain attack on a package
+   that doesn't exist. By the YAGNI rule in this repo's
+   CLAUDE.md, that's a clear cut.
+
+2. **The current threat model holds without it.** Skills loaded
+   from a path inside the user's repo cannot be tampered with
+   without write access to that repo (which itself is the
+   attacker's primary goal). The skill-loader's script-stripping
+   + size cap + frontmatter validator + the runner's
+   untrusted-content wrapper + the injection detector cover the
+   in-skill prompt-injection vector. See
+   [`./threat-model-review-2026-05.md`](./threat-model-review-2026-05.md)
+   findings T-5 and E-3 for the full reasoning.
+
+3. **Cosign carries operational cost.** Verification requires
+   `cosign verify-blob` available in the operator's CI runner —
+   which is not a guarantee on every CI provider, every Lambda
+   image, or every self-hosted environment. We would need an
+   `skills.verify_attestation: false` opt-out for environments
+   without cosign, which means the security posture is
+   per-deployment, not project-wide. That's an operator-confusion
+   surface that's hard to justify against the zero-user benefit.
+
+The v1.1 re-evaluation gate is: **the first first-party
+`@review-agent/skill-*` package is approved for publication.**
+At that point, cosign keyless signing in the publish workflow +
+loader-side `cosign verify-blob` becomes load-bearing and we
+revisit. Until then, this document records the decision and #51
+stays closed.
+
+---
+
+## What we ship instead (v1.0 baseline)
+
+The skill loader's existing defenses, all enforced unconditionally:
+
+| Defense | Code reference | Spec reference |
+|---|---|---|
+| YAML frontmatter validator (Zod schema) | `packages/runner/src/skill-loader.ts` `SkillFrontmatterSchema` | §15.7.4 |
+| 50 KB body size cap | `packages/runner/src/skill-loader.ts` `MAX_SKILL_BYTES` | §15.7.4 |
+| `<script>` tag stripping | `stripScriptyContent` | §15.7.4 |
+| Forbidden fenced-code stripping (bash / sh / shell / powershell / python) | `stripScriptyContent` | §15.7.4 |
+| Untrusted-content wrapper around skill body in the system prompt | `packages/runner/src/prompts/untrusted.ts` | §6.4 |
+| LLM-based injection detector classifies skill content if suspect | `packages/runner/src/security/injection-detector.ts` | §11 |
+| Resolution restricted to relative paths under workspace root (no npm, no `@scope/...` resolution path active) | `defaultResolve` throws on `@`-prefixed names | §15.7.3 |
+
+For the skill *content* itself — what the user puts in
+`.review-agent/skills/<name>/SKILL.md` — the threat model treats
+it as **untrusted operator-supplied input**, not as code. The
+loader does not execute it; the LLM reads it inside the
+untrusted-content wrapper. Tampering with the skill body lets the
+attacker influence the LLM's narrative but not bypass the
+deterministic post-processing (dedup, gitleaks, cost cap).
+
+---
+
+## Re-evaluation triggers for v1.1+
+
+This document is updated and #51 is reopened as a real
+implementation issue when **any** of the following happens:
+
+- A first-party `@review-agent/skill-*` package is approved for
+  publication. Cosign becomes load-bearing the moment the
+  loader can resolve from npm.
+- The community publishes a third-party `@review-agent/skill-*`
+  ecosystem worth integrity-protecting. (Unlikely given the OSS
+  no-contributions stance, but possible if a fork takes off.)
+- A documented incident demonstrates the YAML / script-stripping
+  defenses are insufficient against a real attacker. So far the
+  red-team eval (`packages/eval/fixtures/red-team/`) does not
+  surface any such bypass.
+
+Until at least one of these triggers fires, the v1.0 wontfix
+holds. The fingerprint dedup, gitleaks, cost cap, and
+untrusted-content wrapper continue to provide defense in depth at
+the runner level regardless of what the skill content says.
+
+---
+
+## Cross-references
+
+- [`./threat-model-review-2026-05.md`](./threat-model-review-2026-05.md) — STRIDE walkthrough findings T-5 (Tampering — modified skill content) and E-3 (EoP — skill tells agent to skip review).
+- [`../../packages/runner/src/skill-loader.ts`](../../packages/runner/src/skill-loader.ts) — current loader implementation.
+- [`../../UPGRADING.md`](../../UPGRADING.md) — public API surface; the loader's `loadSkill`, `loadSkills`, `renderSkillsBlock`, `Skill`, `SkillFrontmatter`, `SkillFrontmatterSchema` exports are stable. Adding cosign verification later would extend (not break) this surface.

--- a/docs/security/threat-model-review-2026-05.md
+++ b/docs/security/threat-model-review-2026-05.md
@@ -1,0 +1,209 @@
+# Threat-model review — 2026-05
+
+Structured STRIDE walkthrough against the v0.3 / v1.0 attack
+surface of `review-agent`. Spec reference: PRD §12.1 v1.0 (option
+b: internal threat-model review), v1.0 issue #44, [`./audit.md`](./audit.md).
+
+**Status**: drafted by the project maintainer (almondoo /
+tsubasa.engineer@gmail.com). **Awaiting unaffiliated reviewer
+sign-off** — see "Sign-off" at the bottom. Until that line is
+filled in, this document is a draft and v1.0 tagging is gated.
+
+Scope: every surface listed in the in-scope table below. Out of
+scope: GitHub Actions runner platform itself, LLM provider
+availability, user-supplied skill / `path_instructions` content
+(documented in SECURITY.md "Out of scope").
+
+---
+
+## In-scope surfaces
+
+| Surface | Code reference | Spec reference |
+|---|---|---|
+| Webhook receiver (HMAC + idempotency) | `packages/server/src/handlers/webhook.ts` + `middleware/verify-signature.ts` + `middleware/idempotency.ts` | §7.1, §7.2 |
+| Job queue (SQS / GCP Pub/Sub / etc.) | `packages/server/src/queue/sqs.ts` + `core/queue.ts` | §7.5 |
+| GitHub App auth + token cache | `packages/platform-github/src/app-auth.ts` | §7.4 |
+| BYOK envelope encryption (per-installation) | `packages/core/src/kms/`, `packages/kms-aws/` | §8.5 |
+| Postgres RLS (multi-tenant) | `packages/db/src/migrations/*` | §16.1 |
+| Audit-log HMAC chain | `packages/core/src/audit.ts`, `packages/db/src/append.ts` | §13.3 |
+| Cost ledger + per-installation hard cap | `packages/core/src/cost.ts`, `packages/runner/src/cost-*` | §6.2, §11.1, §17 |
+| Agent loop tool surface (`read_file` / `glob` / `grep` only) | `packages/runner/src/tools.ts` | §11.2 |
+| Sandbox (denylist + partial+sparse clone + non-root container) | `Dockerfile`, `packages/runner/src/tools.ts` | §11.2, §15.1 |
+| Gitleaks (diff scan + agent-output scan) | `packages/runner/src/gitleaks.ts` | §11.3 |
+| Prompt-injection guard (untrusted wrapper + LLM detector) | `packages/runner/src/middleware/injection-guard.ts`, `runner/src/security/injection-detector.ts` | §6.4, §11 |
+| Hidden state comment + fingerprint dedup | `packages/runner/src/state-builder.ts`, `runner/src/middleware/dedup.ts` | §12.1 |
+| Skill loader (frontmatter + script-stripping) | `packages/runner/src/skill-loader.ts` | §15.7.4 |
+| Multi-bot coordination policy | `packages/runner/src/coordination.ts`, `config/src/known-bots.ts` | §22 #9, v1.0 #48 |
+| Bot identity per distribution mode | per [`../configuration/bot-identity.md`](../configuration/bot-identity.md) | §22 #5, v1.0 #47 |
+
+---
+
+## Spoofing
+
+What can an attacker pretend to be that they aren't?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| S-1 | Forged GitHub webhook (no valid HMAC) | `crypto.timingSafeEqual` over the raw body before JSON parse; missing and invalid signatures both 401 with identical body so timing attacks cannot distinguish failure modes. | None at the receiver. Operators must rotate the webhook secret on suspicion (§8.6.3 runbook). |
+| S-2 | Replay of old webhook delivery | Idempotency table on `X-GitHub-Delivery`; duplicate delivery returns `{ deduped: true }` 200. Cleanup sweep removes rows > 7 days. | A window of 7 days where a leaked old signed body could be replayed against a previous receiver instance — but the receiver dedupes, so the worker only runs once. |
+| S-3 | Spoofed Anthropic / OpenAI API responses (intercepted TLS) | Provider SDK uses the underlying TLS stack with default CA bundle. We do not pin certificates. | An attacker with CA-level position could MITM provider calls — out-of-scope per PRD risks §11.2 (provider availability), but operators in regulated environments should consider TLS inspection policy. |
+| S-4 | Spoofed bot author (PR opened by `coderabbitai[bot]` to trigger deference) | `coordination.other_bots: defer_if_present` matches GitHub's `[bot]` actor field which a non-bot account cannot impersonate. | None at the protocol level — actor authenticity is GitHub's responsibility. |
+| S-5 | Forged per-installation BYOK secret | Secrets are envelope-encrypted at rest and the data-key is wrapped under a per-installation CMK. Rotation drops the data-key. | A KMS misconfiguration that grants cross-installation `kms:Decrypt` would breach isolation — KMS policy review is part of `byok.md` runbook. |
+
+Findings: none `high` or `critical`. S-3 is informational
+(industry-default trust model). S-5 has documented mitigation in
+`byok.md`.
+
+---
+
+## Tampering
+
+What can an attacker modify in flight or at rest?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| T-1 | Modified PR diff body before agent reads it | Agent fetches the diff via the GitHub API (TLS), not from arbitrary mirrors. Octokit retries on transient failures only — no fallback to plaintext. | None at the protocol level. |
+| T-2 | Tampered agent-output before `gitleaks` post-scan | Gitleaks runs on agent text in-process before posting; output is held in memory until scan completes. There is no intermediate file write that another process could touch. | None — single-process invariant. |
+| T-3 | Modified hidden state comment to skip review (`<!-- review-agent-state: ... -->`) | The runner treats the state comment as a hint, not a security boundary. Modified state can re-trigger a full re-review (worst case: extra cost, capped by `cost-cap-usd`). It cannot bypass the review entirely because `decideSkip` does not consult it. | An attacker can churn the state comment to drive cost — bounded by per-installation daily cap (§17). Acceptable. |
+| T-4 | Audit-log row tampering (DB compromise) | HMAC chain (`hash_n = sha256(prev_hash || canonical_payload_n)`); `recover audit-verify` detects any modification. Verifier runs nightly (recommended). | A tamperer with both DB write and the chain salt could theoretically forge a consistent chain — but the salt is derived from `prev_hash`, not a separate secret, so the forge is computationally bounded by the SHA-256 collision space. Acceptable. |
+| T-5 | Modified skill content in `.review-agent/skills/` | Skill loader strips `<script>` tags and dangerous fenced-code blocks (`bash` / `sh` / `python` / `powershell`). 50 KB max size. Untrusted-content wrapper marks skill body as not instructions. | An LLM might still treat skill content as authoritative even with the wrapper. The `skill-loader.test.ts` covers the strip; the LLM-side trust is mitigated by the injection detector (`runner/src/security/injection-detector.ts`). |
+
+Findings: none `high` or `critical`. T-3 and T-5 have documented
+mitigations and acceptable residual risk.
+
+---
+
+## Repudiation
+
+What actions can an attacker take and then deny?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| R-1 | Operator denies running an expensive prompt | `audit_log` HMAC chain records every cost-incurring event with `installation_id`, `pr_id`, `event`, `model`, `input_tokens`, `output_tokens`. Forward-only with chain replay. | None at the protocol level. The forensic record is regulatory-grade (§8.6.5). |
+| R-2 | Worker process emits a comment then disappears | Server posts the comment via Octokit which logs the operation in the GitHub PR timeline. The Lambda log retains the request. | Comment authorship is tied to the bot identity per [`../configuration/bot-identity.md`](../configuration/bot-identity.md) — per-mode mapping is documented so auditors know which actor maps to which deployment. |
+| R-3 | Tenant denies agreeing to a config policy | Org config is read from `<owner>/.github/review-agent.yml` at job time and the source is recorded in OTel (`metrics.configSourceTotal.add(1, { source })`). | Telemetry is operator-side, not a hard audit row. Acceptable for the org-config trust model. |
+
+Findings: none. Audit-log + GitHub timeline + OTel cover the
+relevant cases.
+
+---
+
+## Information disclosure
+
+What sensitive data can an attacker read?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| I-1 | Agent reads `.env` / `.git/config` / `node_modules/` lockfiles | Static denylist in `tools.ts`; partial+sparse clone of changed paths only, rooted at the clone dir. Symlinks are refused (`statSync(file).isSymbolicLink()`). | None at the tool layer. An attacker who lands a path in the diff that resolves into a denylisted dir gets refused with `ToolDispatchRefusedError`. |
+| I-2 | Secret in agent reasoning leaks via posted comment | Two-stage gitleaks: diff scan + agent-text scan. Review aborts on positive hit (`shouldAbortReview` returns true). Tested via `runner/src/gitleaks.test.ts`. | A custom secret format not in gitleaks's default rules could slip through — operators add `redact_patterns` in `.review-agent.yml` for org-specific secrets. |
+| I-3 | Cross-tenant data leak via shared Postgres | RLS `tenant_isolation` policy on every tenant-scoped table; `app.current_tenant` GUC is required for read; fails closed when GUC unset. Migrations superuser path is the only RLS-bypass and is gated to migration scripts. | A code path that forgets `SET LOCAL app.current_tenant = '<id>'` would silently return zero rows (fail-closed). Tested in db/src/__tests__/rls.test.ts. |
+| I-4 | Per-installation BYOK secret read by neighbouring installation | Envelope encryption: data-key wrapped under per-installation CMK. Decryption requires both the wrapped data-key and `kms:Decrypt` on the CMK ARN. KMS policy scopes by installation. | Cross-installation `kms:Decrypt` grant is the only way to breach isolation — operator audit responsibility per `byok.md`. |
+| I-5 | Prompt-injection extracts the system prompt | Untrusted-content wrapper + injection detector + the agent loop's own instruction-following defenses. Red-team eval has 15 fixtures targeting this. | Bypass attempts that the eval doesn't cover are possible — the eval gate is `red_team_bypass_count = 0` (`baseline.json`); any new bypass is treated as a red-team fixture and shipped in the fix PR. |
+| I-6 | Cost-ledger HMAC chain entry leaks PR contents | `audit_log` rows store metadata only (`event`, `model`, token counts, `pr_id`), not prompt/completion bodies. Body redaction is enforced by `body-redaction.ts`. | None at the row schema level. |
+| I-7 | Debug logs include the inference API key | API keys are read via env vars and never written to OTel attributes or stdout. `body-redaction.ts` strips `Authorization` headers from spans. | An operator wiring custom OTel attributes could log it manually — out-of-band review responsibility. |
+
+Findings: none `high` or `critical`. I-2 and I-5 depend on the
+ongoing red-team / detection-rule maintenance cadence.
+
+---
+
+## Denial of service
+
+What can an attacker do to make the agent unavailable or expensive?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| D-1 | PR opened with a 10MB diff to inflate cost | `reviews.max_diff_lines` (default 3000), `reviews.max_files` (default 50), per-PR `cost-cap-usd` (default 1.0), per-installation `daily_cap_usd` (default 50). The cost-guard middleware short-circuits the loop when the cap is reached. | None at the cap level. An attacker can saturate the daily cap to lock other PRs for 24h — operators tune the cap based on their volume. |
+| D-2 | High-frequency PR open / synchronize loop | Synchronize debounce (`startWorker` checks the latest `review_state` head SHA and drops messages within the 5s debounce window). | Sustained high-frequency push from a compromised installation would still consume worker CPU until the cap kicks in — acceptable. |
+| D-3 | Webhook receiver overload | Lambda concurrency cap, SQS queue absorbs bursts, partial-batch failure handler isolates poison messages (`maxReceiveCount: 5` then DLQ). | None at the protocol level. |
+| D-4 | Agent loop infinite tool calls | Tool-call budget per turn; cost-guard middleware aborts when projected cost exceeds the cap. | None — bounded by cap. |
+| D-5 | LLM-based injection detector loop | Detector cache (`createInMemoryDetectorCache`) deduplicates classifications per process. The detector itself is bounded by token budget. | The detector adds ~$0.001/PR overhead (PRD §22 #14); this is mandatory in v1.0 with `INJECTION_DETECTOR_OPT_OUT_ENV` for opt-out where defended in another layer. |
+
+Findings: none `high` or `critical`. D-1 and D-5 are budget-bounded
+by design.
+
+---
+
+## Elevation of privilege
+
+What can an attacker do to gain capabilities they shouldn't have?
+
+| # | Attack | Mitigation | Residual risk |
+|---|---|---|---|
+| E-1 | Agent escapes the sandboxed clone directory | `read_file` resolves the requested path against the clone root and refuses traversal. The `agent` user inside the container is non-root and `REVIEW_AGENT_SANDBOXED=1` is set. | A bug in the path-resolution code is the entire boundary — `runner/src/tools.test.ts` covers `..` traversal, symlink, and absolute-path attacks. |
+| E-2 | Agent issues GitHub API calls outside the configured tool surface | The agent loop only ever exposes `read_file` / `glob` / `grep` to the LLM. There is no tool that lets the LLM call the GitHub API. | None at the loop level. The only GitHub API caller is the platform adapter, which is invoked by the runner / action wrapper, not by tool dispatch. |
+| E-3 | Skill content tells the agent to skip the review | Untrusted-content wrapper marks skill body as informational-only; injection detector classifies suspect content. | An LLM that ignores the wrapper is still bounded by the deterministic post-processing — `dedupComments` and `gitleaks` run regardless of the agent's narrative. |
+| E-4 | A multi-tenant operator escalates to another tenant via SQL injection | All Postgres queries use Drizzle's parameterised placeholders. No raw `${}` interpolation in `packages/db/src/`. | None at the query layer. |
+| E-5 | Bot identity confusion between Action and Server modes lets one masquerade as the other | Per [`../configuration/bot-identity.md`](../configuration/bot-identity.md), GitHub determines the actor per auth method; there is no config knob that lets a deployment misrepresent its mode. | None at the protocol level. |
+
+Findings: none. The single-purpose tool surface and Drizzle-only
+query layer materially shrink the EoP attack surface.
+
+---
+
+## Summary of findings
+
+**Pre-review counts** (drafted by maintainer, awaiting reviewer
+sign-off):
+
+| Severity | Count | Notes |
+|---|---|---|
+| Critical | 0 | — |
+| High | 0 | — |
+| Medium | 0 | — |
+| Low | 0 | — |
+| Informational | 4 | S-3 (TLS pinning policy), T-3 (state-comment churn driving cost — bounded by cap), I-2 (custom secret formats — operator-extensible via `redact_patterns`), D-1 (daily-cap saturation lock — operator-tunable). |
+
+No findings block v1.0 tagging on technical merit. The remaining
+gate is the unaffiliated-reviewer sign-off below.
+
+If the reviewer flags additional findings, this section is
+updated to reflect them and the corresponding rows are added to
+the relevant STRIDE category above.
+
+---
+
+## Recommendations for v1.x follow-up
+
+These are not v1.0 blockers but are tracked for the next minor:
+
+1. **Cosign attestation for first-party skills** — currently a
+   wontfix per v1.0 issue #51 (no `@review-agent/skill-*`
+   packages exist). Re-evaluate when the first skill is published.
+2. **Custom-secret format library**: ship a starter
+   `redact_patterns` example for common per-org secret formats
+   (UUID-suffixed tokens, internal `acme-*` prefixes). Today
+   operators have to write the regex from scratch.
+3. **TLS pinning policy guidance** in `docs/security/`: document
+   the operator's options for TLS inspection / pinning when their
+   network policy requires it. Today the project trusts the
+   default CA bundle.
+4. **Redacted forensic export tool**: a `review-agent forensics
+   export-audit` CLI subcommand that exports the audit-log chain
+   in a portable, redacted form for a customer-comms ticket.
+   Today operators run `psql` directly.
+
+---
+
+## Sign-off
+
+This walkthrough is **drafted** and **not yet signed off**. The
+maintainer's sign-off alone does NOT close v1.0 issue #44 — see
+[`./audit.md`](./audit.md) for the procedure.
+
+| Reviewer | Affiliation | Date | Verdict |
+|---|---|---|---|
+| almondoo (Tsubasa) | maintainer (primary author) | 2026-05-03 | drafted |
+| _TBD — unaffiliated reviewer required_ | _TBD_ | _TBD_ | _pending_ |
+
+When the unaffiliated reviewer signs off, append a row above and
+flip the STATUS line at the top of this document. v1.0 issue #44
+can then be closed.
+
+---
+
+## Cross-references
+
+- [`./audit.md`](./audit.md) — procedure and decision rationale.
+- [`../../SECURITY.md`](../../SECURITY.md) — published threat model (kept in sync with this walkthrough).
+- [`../../UPGRADING.md`](../../UPGRADING.md) — public API surface that the walkthrough's `tampering` and `EoP` sections protect.

--- a/docs/specs/prd.md
+++ b/docs/specs/prd.md
@@ -389,6 +389,7 @@ v0.1 リリース前に解決が必要。番号は実装仕様書 §22 のオー
 9. **複数 review bot 衝突** — `coderabbitai[bot]` 等が同居する場合の重複回避
 10. **OSS テレメトリ opt-in** — 匿名利用統計を出すか? 出すなら何を、どう同意取得するか
 11. **GHES (Enterprise Server) 互換性** — declared support / no-support / "best-effort" のどれか
+    → **v1.0 決定**: `best-effort, no commitment`。CI で GHES を回さず、issues は受けるが PR は受けない。詳細は [`docs/deployment/ghes.md`](../deployment/ghes.md)。
 12. **プロバイダ feature parity matrix の公開** — eval 結果 delta を docs に出すか
 13. **OpenAI 互換エンドポイント preset** — `ollama:llama3:70b` 等の known-good preset を schema に含めるか
 14. **LLM-based injection detector のコスト** — ~$0.001/PR の overhead を mandatory（現状）か opt-out に変更するか
@@ -489,7 +490,7 @@ v0.1 リリース前に解決が必要。番号は実装仕様書 §22 のオー
 - [ ] API 安定性宣言（SemVer に移行、UPGRADING.md 整備）
 - [ ] OSS 公開判断（公開する場合は CODE_OF_CONDUCT.md / GOVERNANCE.md 整備、README/CONTRIBUTING を OSS モードに更新）
 
-**Post-v1.0** — GitLab adapter、Bitbucket adapter、GHES 対応、IDE プレビュー、コミュニティ形成施策（OSS 公開する場合）
+**Post-v1.0** — GitLab adapter、Bitbucket adapter、GHES の declared-support 化（v1.0 では best-effort, no commitment、[`docs/deployment/ghes.md`](../deployment/ghes.md)）、IDE プレビュー、コミュニティ形成施策（OSS 公開する場合）
 
 ---
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -19,6 +19,14 @@ point.
 - `posted-comments` — number of inline comments posted.
 - `cost-usd` — USD cost of this run.
 
+## Bot identity
+
+In Action mode comments are posted by `github-actions[bot]` (the
+identity tied to `secrets.GITHUB_TOKEN`). For multi-repo audit-trail
+uniformity, run the GitHub App (Server mode) instead — see
+[`docs/configuration/bot-identity.md`](../../docs/configuration/bot-identity.md)
+for the per-mode mapping.
+
 ## License
 
 Apache-2.0

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -34,5 +34,5 @@ outputs:
     description: USD cost of this review.
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/packages/action/src/run.test.ts
+++ b/packages/action/src/run.test.ts
@@ -122,6 +122,104 @@ describe('runAction', () => {
     expect(stateArg?.modelUsed).toBe('claude-sonnet-4-6');
   });
 
+  it('defers when coordination.other_bots is defer_if_present and a known bot has commented', async () => {
+    const vcs = makeVCS({
+      getExistingComments: vi.fn(async () => [
+        {
+          id: 1,
+          path: 'a.ts',
+          line: 1,
+          side: 'RIGHT' as const,
+          body: 'looks good',
+          author: 'coderabbitai[bot]',
+          createdAt: '',
+        },
+      ]),
+    });
+    const result = await runAction(
+      inputs,
+      { ref },
+      {
+        readFile: async () => 'coordination:\n  other_bots: defer_if_present\n',
+        createVCS: () => vcs,
+        createProvider: () => makeProvider(),
+      },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toContain('coderabbitai[bot]');
+    // Posts the deferral summary, but no inline review and no state row.
+    expect(vcs.postSummary).toHaveBeenCalledTimes(1);
+    expect(vcs.postReview).not.toHaveBeenCalled();
+    expect(vcs.upsertStateComment).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with the review when coordination.other_bots is ignore even if a known bot has commented', async () => {
+    const vcs = makeVCS({
+      getExistingComments: vi.fn(async () => [
+        {
+          id: 1,
+          path: 'a.ts',
+          line: 1,
+          side: 'RIGHT' as const,
+          body: 'looks good',
+          author: 'coderabbitai[bot]',
+          createdAt: '',
+        },
+      ]),
+    });
+    const result = await runAction(
+      inputs,
+      { ref },
+      {
+        // Explicit `ignore` rather than empty YAML so the test fails
+        // if a future change to `defaultConfig` flips the default.
+        readFile: async () => 'coordination:\n  other_bots: ignore\n',
+        createVCS: () => vcs,
+        createProvider: () => makeProvider(),
+      },
+    );
+    expect(result.skipped).toBe(false);
+    expect(vcs.postReview).toHaveBeenCalledTimes(1);
+    // Short-circuit invariant: ignore mode does not call
+    // getExistingComments, so we don't pay the API call when
+    // coordination is off.
+    expect(vcs.getExistingComments).not.toHaveBeenCalled();
+  });
+
+  it('respects coordination.other_bots_logins for operator-supplied custom bot logins', async () => {
+    const vcs = makeVCS({
+      getExistingComments: vi.fn(async () => [
+        {
+          id: 1,
+          path: 'a.ts',
+          line: 1,
+          side: 'RIGHT' as const,
+          body: 'looks good',
+          author: 'acme-internal-reviewer[bot]',
+          createdAt: '',
+        },
+      ]),
+    });
+    const yaml = [
+      'coordination:',
+      '  other_bots: defer_if_present',
+      '  other_bots_logins:',
+      '    - acme-internal-reviewer[bot]',
+      '',
+    ].join('\n');
+    const result = await runAction(
+      inputs,
+      { ref },
+      {
+        readFile: async () => yaml,
+        createVCS: () => vcs,
+        createProvider: () => makeProvider(),
+      },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toContain('acme-internal-reviewer[bot]');
+  });
+
   it('surfaces cost-cap violations as a thrown error and posts no comments', async () => {
     const vcs = makeVCS();
     const provider = makeProvider();

--- a/packages/action/src/run.ts
+++ b/packages/action/src/run.ts
@@ -1,12 +1,20 @@
 import { readFile } from 'node:fs/promises';
-import { type Config, defaultConfig, loadConfigFromYaml, mergeWithEnv } from '@review-agent/config';
+import {
+  type Config,
+  defaultConfig,
+  KNOWN_REVIEW_BOT_LOGINS,
+  loadConfigFromYaml,
+  mergeWithEnv,
+} from '@review-agent/config';
 import type { PR, PRRef, ReviewState, VCS } from '@review-agent/core';
 import { createAnthropicProvider, type LlmProvider } from '@review-agent/llm';
 import { createGithubVCS } from '@review-agent/platform-github';
 import {
   buildReviewState,
+  decideCoordination,
   loadSkills,
   type RunnerResult,
+  renderDeferralSummary,
   renderSkillsBlock,
   runReview,
 } from '@review-agent/runner';
@@ -52,6 +60,12 @@ export async function runAction(
 
   const skipReason = decideSkip(pr, config);
   if (skipReason) return { ...NO_RUN, skipReason };
+
+  const coordination = await decideCoordinationForRun(vcs, ctx.ref, config);
+  if (coordination.action === 'defer') {
+    await vcs.postSummary(ctx.ref, renderDeferralSummary(coordination.bot));
+    return { ...NO_RUN, skipReason: `Deferred to '${coordination.bot}' (coordination policy)` };
+  }
 
   const provider = (deps.createProvider ?? ((key, cfg) => buildAnthropicProvider(key, cfg)))(
     inputs.anthropicApiKey ?? '',
@@ -104,6 +118,30 @@ function decideSkip(pr: PR, config: Config): string | null {
     return `Author '${pr.author}' is in ignore_authors`;
   }
   return null;
+}
+
+// Lists existing PR comments and runs the coordination decision so
+// the action defers to another review bot when configured. The VCS
+// adapter's `getExistingComments` returns inline review comments
+// only — bots that post solely a summary PR comment (no inline
+// comments at all) are NOT detected here even when added to
+// `coordination.other_bots_logins`. Extending the VCS adapter to
+// also list `issues.listComments` authors is tracked as a v1.x
+// follow-up. See `docs/configuration/coordination.md`.
+async function decideCoordinationForRun(
+  vcs: VCS,
+  ref: PRRef,
+  config: Config,
+): Promise<ReturnType<typeof decideCoordination>> {
+  if (config.coordination.other_bots === 'ignore') {
+    return { action: 'proceed' };
+  }
+  const existing = await vcs.getExistingComments(ref);
+  return decideCoordination({
+    mode: config.coordination.other_bots,
+    botLogins: [...KNOWN_REVIEW_BOT_LOGINS, ...config.coordination.other_bots_logins],
+    existingCommentAuthors: existing.map((c) => c.author),
+  });
 }
 
 async function loadConfigOrDefault(

--- a/packages/action/tsup.config.ts
+++ b/packages/action/tsup.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
   target: 'node24',
   outDir: 'dist',
   bundle: true,
+  // CJS deps bundled into the ESM output (e.g. yaml@2.8.x's
+  // composer.js) call `require('process')`. tsup's default ESM shim
+  // refuses dynamic require with `Error: Dynamic require of "..." is
+  // not supported`. Wire `createRequire(import.meta.url)` into the
+  // bundle banner so those `require()` calls resolve at runtime.
+  banner: {
+    js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
+  },
   noExternal: [
     '@review-agent/core',
     '@review-agent/llm',

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,34 @@
+# @review-agent/cli
+
+Local CLI for `review-agent`. Run a one-off review against a single PR
+using a Personal Access Token, validate `.review-agent.yml`, dump the
+JSON Schema for IDE wiring, and recover state after a Postgres loss.
+
+## Commands
+
+```bash
+review-agent review --repo owner/name --pr 42 --post
+review-agent config validate [path]
+review-agent config schema > schema/v1.json
+review-agent eval --suite golden
+review-agent recover sync-state --repo owner/name --installation 123
+review-agent setup workspace                     # manual checklist (Anthropic Workspace + ZDR + spend cap)
+review-agent setup workspace --api               # uses ANTHROPIC_ADMIN_KEY
+```
+
+`--post` is opt-in. The default `review` invocation prints the
+findings to stdout without writing to GitHub — useful for prompt
+tuning and gating.
+
+## Bot identity
+
+In CLI mode comments are posted under the PAT owner's user account
+(e.g. `alice`). This is intentional for interactive operator use,
+but means audit logs cannot distinguish "human reviewed" from "agent
+reviewed via CLI". For multi-repo audit-trail uniformity use the
+GitHub App (Server mode); see
+[`docs/configuration/bot-identity.md`](../../docs/configuration/bot-identity.md).
+
+## License
+
+Apache-2.0

--- a/packages/cli/src/commands/setup-workspace.test.ts
+++ b/packages/cli/src/commands/setup-workspace.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setupWorkspaceCommand } from './setup-workspace.js';
+
+function recordingIo() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    stdout: (c: string) => {
+      out.push(c);
+    },
+    stderr: (c: string) => {
+      err.push(c);
+    },
+    exit: () => {},
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('setupWorkspaceCommand — manual mode (default)', () => {
+  it('prints the manual checklist with the configured workspace name', async () => {
+    const io = recordingIo();
+    const result = await setupWorkspaceCommand(io, {
+      env: {} as NodeJS.ProcessEnv,
+      name: 'acme-review',
+      spendCapUsd: 25,
+    });
+    expect(result.status).toBe('manual');
+    const body = io.out.join('');
+    expect(body).toContain('manual checklist');
+    expect(body).toContain('Name: acme-review');
+    expect(body).toContain('USD 25');
+    // Defaults are surfaced so the operator can copy them as-is.
+    expect(body).toContain('claude-sonnet-4-6');
+    expect(body).toContain('ANTHROPIC_API_KEY');
+    expect(io.err.join('')).toBe('');
+  });
+
+  it('uses default name and spend cap when none provided', async () => {
+    const io = recordingIo();
+    const result = await setupWorkspaceCommand(io, { env: {} as NodeJS.ProcessEnv });
+    expect(result.status).toBe('manual');
+    const body = io.out.join('');
+    expect(body).toContain('Name: review-agent');
+    expect(body).toContain('USD 50');
+  });
+});
+
+describe('setupWorkspaceCommand — --api mode', () => {
+  it('reports auth_failed when ANTHROPIC_ADMIN_KEY is missing', async () => {
+    const io = recordingIo();
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(result.status).toBe('auth_failed');
+    expect(io.err.join('')).toContain('ANTHROPIC_ADMIN_KEY');
+  });
+
+  it('creates workspace and sets spend cap when both endpoints succeed', async () => {
+    const io = recordingIo();
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ id: 'ws_123' }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      name: 'rev',
+      spendCapUsd: 10,
+      fetchFn,
+    });
+    expect(result).toEqual({ status: 'api_ok', workspaceId: 'ws_123' });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [createUrl, createInit] = fetchFn.mock.calls[0] ?? [];
+    expect(createUrl).toBe('https://api.anthropic.com/v1/organizations/workspaces');
+    expect(createInit?.method).toBe('POST');
+    expect((createInit?.headers as Record<string, string>)['x-api-key']).toBe('sk-admin-test');
+    expect(JSON.parse(String(createInit?.body))).toEqual({ name: 'rev' });
+
+    const [capUrl, capInit] = fetchFn.mock.calls[1] ?? [];
+    expect(capUrl).toBe('https://api.anthropic.com/v1/organizations/workspaces/ws_123/spend_limit');
+    expect(JSON.parse(String(capInit?.body))).toEqual({ limit_usd_per_month: 10 });
+
+    const out = io.out.join('');
+    expect(out).toContain("Created workspace 'rev'");
+    expect(out).toContain('USD 10');
+    expect(out).toContain('Workspace id: ws_123');
+  });
+
+  it('reports api_failed when the workspace create call returns non-2xx', async () => {
+    const io = recordingIo();
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('forbidden', { status: 403, statusText: 'Forbidden' }));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(result.status).toBe('api_failed');
+    expect(result.workspaceId).toBeUndefined();
+    expect(io.err.join('')).toContain('403');
+    // Spend-cap call must not run if workspace create failed.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports api_failed when the spend-cap call fails after a successful workspace create', async () => {
+    const io = recordingIo();
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ id: 'ws_456' }))
+      .mockResolvedValueOnce(new Response('limit', { status: 422, statusText: 'Unprocessable' }));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(result.status).toBe('api_failed');
+    // Workspace id is still returned so the operator can clean up manually.
+    expect(result.workspaceId).toBe('ws_456');
+    expect(io.err.join('')).toContain('422');
+  });
+
+  it('reports api_failed when the workspace create response has no id', async () => {
+    const io = recordingIo();
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({}));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(result.status).toBe('api_failed');
+    expect(io.err.join('')).toContain('no id');
+  });
+
+  it('reports api_failed and the underlying message when the workspace create throws', async () => {
+    const io = recordingIo();
+    const fetchFn = vi.fn<typeof fetch>().mockRejectedValueOnce(new Error('network down'));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(result.status).toBe('api_failed');
+    expect(result.errorMessage).toBe('network down');
+  });
+
+  it('reports api_failed when the spend-cap fetch itself throws after a successful create', async () => {
+    const io = recordingIo();
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ id: 'ws_throw' }))
+      .mockRejectedValueOnce(new Error('cap network blip'));
+    const result = await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: 'sk-admin-test' } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(result.status).toBe('api_failed');
+    expect(result.workspaceId).toBe('ws_throw');
+    expect(result.errorMessage).toBe('cap network blip');
+    expect(io.err.join('')).toContain('cap network blip');
+  });
+
+  it('does not log the admin key in stdout or stderr (success path)', async () => {
+    const io = recordingIo();
+    const adminKey = 'sk-admin-secret-VERY-SENSITIVE';
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ id: 'ws_x' }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: adminKey } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(io.out.join('')).not.toContain(adminKey);
+    expect(io.err.join('')).not.toContain(adminKey);
+  });
+
+  it('does not log the admin key in stdout or stderr (error path)', async () => {
+    // Regression guard: a future change that dumps the request init
+    // (which contains the `x-api-key` header) into stderr on error
+    // would slip past the success-path assertion above. This case
+    // exercises the non-2xx branch explicitly.
+    const io = recordingIo();
+    const adminKey = 'sk-admin-secret-VERY-SENSITIVE-error';
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('boom', { status: 500, statusText: 'Server' }));
+    await setupWorkspaceCommand(io, {
+      api: true,
+      env: { ANTHROPIC_ADMIN_KEY: adminKey } as NodeJS.ProcessEnv,
+      fetchFn,
+    });
+    expect(io.out.join('')).not.toContain(adminKey);
+    expect(io.err.join('')).not.toContain(adminKey);
+  });
+});

--- a/packages/cli/src/commands/setup-workspace.ts
+++ b/packages/cli/src/commands/setup-workspace.ts
@@ -1,0 +1,217 @@
+import type { ProgramIo } from '../io.js';
+
+// `review-agent setup workspace` — opt-in onboarding helper for
+// Anthropic Workspace configuration (spec §22 #3 / v1.0 #50). The
+// default mode prints a manual checklist; `--api` calls the
+// Anthropic Admin API directly to create a workspace and set a
+// spend cap, requiring `ANTHROPIC_ADMIN_KEY` (NOT the per-workspace
+// API key). The Admin key is sensitive — we never log it.
+//
+// Provider scope: Anthropic-only today. The command name reads
+// naturally for other providers (`setup workspace --provider openai`)
+// if/when those APIs gain equivalent endpoints.
+
+export type SetupWorkspaceOpts = {
+  /** Use the Anthropic Admin API instead of printing manual steps. */
+  readonly api?: boolean;
+  /** Workspace name (label only). Defaults to `review-agent`. */
+  readonly name?: string;
+  /** Per-workspace monthly spend cap in USD. Defaults to 50. */
+  readonly spendCapUsd?: number;
+  /** Process env. */
+  readonly env: NodeJS.ProcessEnv;
+  /** Test seam: HTTP fetcher for the Anthropic Admin API. */
+  readonly fetchFn?: typeof fetch;
+};
+
+export type SetupWorkspaceResult = {
+  readonly status: 'manual' | 'api_ok' | 'api_failed' | 'auth_failed';
+  readonly workspaceId?: string;
+  readonly errorMessage?: string;
+};
+
+const DEFAULT_NAME = 'review-agent';
+const DEFAULT_SPEND_CAP_USD = 50;
+const ADMIN_KEY_ENV = 'ANTHROPIC_ADMIN_KEY';
+const ANTHROPIC_API_BASE = 'https://api.anthropic.com';
+
+export async function setupWorkspaceCommand(
+  io: ProgramIo,
+  opts: SetupWorkspaceOpts,
+): Promise<SetupWorkspaceResult> {
+  const name = opts.name ?? DEFAULT_NAME;
+  const spendCapUsd = opts.spendCapUsd ?? DEFAULT_SPEND_CAP_USD;
+
+  if (!opts.api) {
+    printManualChecklist(io, { name, spendCapUsd });
+    return { status: 'manual' };
+  }
+
+  const adminKey = opts.env[ADMIN_KEY_ENV];
+  if (!adminKey) {
+    io.stderr(
+      `${ADMIN_KEY_ENV} is required for --api mode.\n` +
+        'Generate one in console.anthropic.com → Settings → Admin Keys.\n' +
+        'The Admin key is distinct from your per-workspace API key — never reuse it for inference.\n',
+    );
+    return { status: 'auth_failed' };
+  }
+
+  const fetchFn = opts.fetchFn ?? fetch;
+  return runApiSetup(io, fetchFn, adminKey, { name, spendCapUsd });
+}
+
+function printManualChecklist(
+  io: ProgramIo,
+  { name, spendCapUsd }: { readonly name: string; readonly spendCapUsd: number },
+): void {
+  io.stdout(
+    [
+      `# review-agent setup workspace — manual checklist`,
+      ``,
+      `Anthropic Workspaces give review-agent isolated billing,`,
+      `spend caps, and Zero Data Retention (ZDR). Follow these steps`,
+      `once per Anthropic organization.`,
+      ``,
+      `## 1. Create a Workspace`,
+      `   - Open https://console.anthropic.com/settings/workspaces`,
+      `   - Click "Create workspace"`,
+      `   - Name: ${name}  (or any label your org uses)`,
+      `   - Description: "code review agent — BYOK self-hosted"`,
+      ``,
+      `## 2. Enable Zero Data Retention (ZDR)`,
+      `   - In the new workspace's Settings tab, toggle ZDR to "on".`,
+      `   - ZDR keeps prompts + completions out of long-term storage.`,
+      `     Required for diff review against private code.`,
+      ``,
+      `## 3. Set a spend cap`,
+      `   - Settings → Spend Limits → set per-month cap to USD ${spendCapUsd}.`,
+      `   - Lower for low-volume orgs; raise after a week of measured cost.`,
+      `   - Spend caps are HARD: requests get rejected with 402 once hit.`,
+      ``,
+      `## 4. Issue a workspace-scoped API key`,
+      `   - Settings → API Keys → Create key`,
+      `   - Scope: this workspace only.`,
+      `   - Copy the key once — it cannot be retrieved later.`,
+      ``,
+      `## 5. Wire it into your deployment`,
+      ``,
+      `   .review-agent.yml:`,
+      `     provider:`,
+      `       type: anthropic`,
+      `       model: claude-sonnet-4-6`,
+      ``,
+      `   .env (or your secret manager):`,
+      `     ANTHROPIC_API_KEY=<the key from step 4>`,
+      ``,
+      `## 6. Verify`,
+      ``,
+      `   review-agent review --repo owner/name --pr 1   # dry run`,
+      ``,
+      `Re-run this command with --api to perform steps 1 + 3 via the`,
+      `Anthropic Admin API instead of clicking. Requires ${ADMIN_KEY_ENV}.`,
+      ``,
+    ].join('\n'),
+  );
+}
+
+async function runApiSetup(
+  io: ProgramIo,
+  fetchFn: typeof fetch,
+  adminKey: string,
+  args: { readonly name: string; readonly spendCapUsd: number },
+): Promise<SetupWorkspaceResult> {
+  // Surface the ZDR-not-automatable caveat BEFORE the first network
+  // call so the operator sees it whether or not the API setup later
+  // succeeds. The Anthropic Admin API does not expose a ZDR toggle;
+  // the operator must enable it manually in the console regardless
+  // of which mode this command runs in.
+  io.stdout(
+    'Note: ZDR cannot be enabled via the Anthropic Admin API. After this command finishes, enable ZDR manually in console.anthropic.com → workspace → Settings.\n',
+  );
+  const headers = {
+    'x-api-key': adminKey,
+    'anthropic-version': '2023-06-01',
+    'content-type': 'application/json',
+  };
+
+  let workspaceId: string;
+  try {
+    const created = await fetchFn(`${ANTHROPIC_API_BASE}/v1/organizations/workspaces`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: args.name }),
+    });
+    if (!created.ok) {
+      const body = await safeText(created);
+      io.stderr(`Workspace create failed: ${created.status} ${created.statusText}\n${body}\n`);
+      return { status: 'api_failed', errorMessage: `${created.status} ${created.statusText}` };
+    }
+    const json = (await created.json()) as { id?: string };
+    if (!json.id) {
+      io.stderr('Workspace create returned no id; cannot continue.\n');
+      return { status: 'api_failed', errorMessage: 'missing workspace id in response' };
+    }
+    workspaceId = json.id;
+    io.stdout(`Created workspace '${args.name}' (id=${workspaceId}).\n`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    io.stderr(`Workspace create error: ${message}\n`);
+    return { status: 'api_failed', errorMessage: message };
+  }
+
+  try {
+    const cap = await fetchFn(
+      `${ANTHROPIC_API_BASE}/v1/organizations/workspaces/${workspaceId}/spend_limit`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ limit_usd_per_month: args.spendCapUsd }),
+      },
+    );
+    if (!cap.ok) {
+      const body = await safeText(cap);
+      io.stderr(`Spend cap set failed: ${cap.status} ${cap.statusText}\n${body}\n`);
+      return {
+        status: 'api_failed',
+        workspaceId,
+        errorMessage: `${cap.status} ${cap.statusText}`,
+      };
+    }
+    io.stdout(`Set monthly spend cap to USD ${args.spendCapUsd}.\n`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    io.stderr(`Spend cap error: ${message}\n`);
+    return { status: 'api_failed', workspaceId, errorMessage: message };
+  }
+
+  io.stdout(
+    [
+      ``,
+      `Next steps (manual):`,
+      `  1. In console.anthropic.com → workspace '${args.name}' → Settings,`,
+      `     enable ZDR. The Admin API does not expose ZDR toggling.`,
+      `  2. Settings → API Keys → Create a workspace-scoped key.`,
+      `     Copy it once — it cannot be retrieved later.`,
+      `  3. Set ANTHROPIC_API_KEY=<that key> in your deployment env.`,
+      ``,
+      `.review-agent.yml snippet:`,
+      `  provider:`,
+      `    type: anthropic`,
+      `    model: claude-sonnet-4-6`,
+      ``,
+      `Workspace id: ${workspaceId}`,
+      ``,
+    ].join('\n'),
+  );
+
+  return { status: 'api_ok', workspaceId };
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -24,16 +24,19 @@ function recordingIo() {
 }
 
 describe('buildProgram', () => {
-  it('exposes the four top-level commands', () => {
+  it('exposes the top-level commands including setup', () => {
     const program = buildProgram({ io: recordingIo(), env: {}, version: 'test' });
     const names = program.commands.map((c) => c.name());
     expect(names).toContain('review');
     expect(names).toContain('config');
     expect(names).toContain('eval');
+    expect(names).toContain('setup');
     const config = program.commands.find((c) => c.name() === 'config');
     const subNames = config?.commands.map((c) => c.name());
     expect(subNames).toContain('validate');
     expect(subNames).toContain('schema');
+    const setup = program.commands.find((c) => c.name() === 'setup');
+    expect(setup?.commands.map((c) => c.name())).toContain('workspace');
   });
 
   it('wires `config schema` to print to stdout', async () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,6 +3,7 @@ import { runEvalCommand } from './commands/eval.js';
 import { recoverSyncStateCommand } from './commands/recover.js';
 import { runReviewCommand } from './commands/review.js';
 import { printSchemaCommand } from './commands/schema.js';
+import { setupWorkspaceCommand } from './commands/setup-workspace.js';
 import { validateConfigCommand } from './commands/validate.js';
 import { defaultIo, type ProgramIo } from './io.js';
 
@@ -76,6 +77,28 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
       io.exit(result.exitCode);
     });
 
+  const setup = program
+    .command('setup')
+    .description('Onboarding helpers (Anthropic Workspace, etc.).');
+
+  setup
+    .command('workspace')
+    .description(
+      'Configure an Anthropic Workspace for review-agent (ZDR + spend cap). Prints a manual checklist by default; --api uses the Admin API.',
+    )
+    .option('--api', 'call the Anthropic Admin API directly (requires ANTHROPIC_ADMIN_KEY)', false)
+    .option('--name <name>', 'workspace name', 'review-agent')
+    .option('--spend-cap-usd <usd>', 'monthly spend cap in USD', (v) => Number.parseFloat(v), 50)
+    .action(async (opts: SetupWorkspaceCliOpts) => {
+      const result = await setupWorkspaceCommand(io, {
+        api: !!opts.api,
+        env,
+        ...(opts.name !== undefined ? { name: opts.name } : {}),
+        ...(opts.spendCapUsd !== undefined ? { spendCapUsd: opts.spendCapUsd } : {}),
+      });
+      io.exit(result.status === 'manual' || result.status === 'api_ok' ? 0 : 1);
+    });
+
   const recover = program
     .command('recover')
     .description('Disaster-recovery commands (spec §8.6.6).');
@@ -117,6 +140,12 @@ type EvalCliOpts = {
 type RecoverSyncStateCliOpts = {
   repo: string;
   installation: bigint;
+};
+
+type SetupWorkspaceCliOpts = {
+  api?: boolean;
+  name?: string;
+  spendCapUsd?: number;
 };
 
 export type { ProgramIo } from './io.js';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,9 @@
 export { generateJsonSchema } from './json-schema.js';
+export {
+  isKnownReviewBotLogin,
+  KNOWN_REVIEW_BOT_LOGINS,
+  type KnownReviewBotLogin,
+} from './known-bots.js';
 export { isSupportedLanguage, SUPPORTED_LANGUAGES, type SupportedLanguage } from './languages.js';
 export {
   defaultConfig,

--- a/packages/config/src/known-bots.test.ts
+++ b/packages/config/src/known-bots.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isKnownReviewBotLogin, KNOWN_REVIEW_BOT_LOGINS } from './known-bots.js';
+
+describe('KNOWN_REVIEW_BOT_LOGINS', () => {
+  it('includes the four bots called out in the v1.0 #48 acceptance criteria', () => {
+    // Pinned to the acceptance-criteria list in issue #48 so adding a
+    // new bot to the constant doesn't silently drop one of the
+    // canonical four. New entries are additive.
+    for (const expected of [
+      'coderabbitai[bot]',
+      'qodo-merge[bot]',
+      'pr-agent-bot[bot]',
+      'bedrock-pr-reviewer[bot]',
+    ]) {
+      expect(KNOWN_REVIEW_BOT_LOGINS).toContain(expected);
+    }
+  });
+
+  it('only lists [bot]-suffixed App actors (no plain users)', () => {
+    // Operator overrides go in `coordination.other_bots_logins`. The
+    // built-in list is for App actors only — a plain login here would
+    // make the substring/case-insensitive false-positive risk worse.
+    for (const login of KNOWN_REVIEW_BOT_LOGINS) {
+      expect(login).toMatch(/\[bot\]$/);
+    }
+  });
+});
+
+describe('isKnownReviewBotLogin', () => {
+  it('recognises a known bot login', () => {
+    expect(isKnownReviewBotLogin('coderabbitai[bot]')).toBe(true);
+  });
+
+  it('rejects unknown logins (no partial / case-insensitive match)', () => {
+    expect(isKnownReviewBotLogin('coderabbit-fan')).toBe(false);
+    expect(isKnownReviewBotLogin('CodeRabbitAI[bot]')).toBe(false);
+    expect(isKnownReviewBotLogin('human-reviewer')).toBe(false);
+  });
+});

--- a/packages/config/src/known-bots.ts
+++ b/packages/config/src/known-bots.ts
@@ -1,0 +1,26 @@
+// Static allowlist of GitHub logins for known PR review bots that
+// review-agent will defer to when `coordination.other_bots:
+// defer_if_present` is set (spec §22 #9 / v1.0 #48).
+//
+// Operators extend this set via `coordination.other_bots_logins:` in
+// `.review-agent.yml`; they cannot remove built-in entries through
+// config (the assumption being that an operator who explicitly opted
+// into deference wants to defer to all known reviewers, not just a
+// subset). Use the `ignore` mode if a given login should NOT trigger
+// deference.
+//
+// Naming follows GitHub's `[bot]`-suffix convention for App actors.
+// Plain user / PAT accounts (e.g. self-hosted reviewers) belong in
+// the operator override list, not here.
+export const KNOWN_REVIEW_BOT_LOGINS = [
+  'coderabbitai[bot]',
+  'qodo-merge[bot]',
+  'pr-agent-bot[bot]',
+  'bedrock-pr-reviewer[bot]',
+] as const;
+
+export type KnownReviewBotLogin = (typeof KNOWN_REVIEW_BOT_LOGINS)[number];
+
+export function isKnownReviewBotLogin(login: string): login is KnownReviewBotLogin {
+  return (KNOWN_REVIEW_BOT_LOGINS as ReadonlyArray<string>).includes(login);
+}

--- a/packages/config/src/loader.test.ts
+++ b/packages/config/src/loader.test.ts
@@ -64,6 +64,26 @@ describe('loadConfigFromYaml — explicit values', () => {
   it('rejects negative cost cap', () => {
     expect(() => loadConfigFromYaml('cost:\n  max_usd_per_pr: -1\n')).toThrow(ConfigError);
   });
+
+  it('defaults coordination.other_bots to ignore with no operator overrides', () => {
+    const cfg = loadConfigFromYaml('');
+    expect(cfg.coordination.other_bots).toBe('ignore');
+    expect(cfg.coordination.other_bots_logins).toEqual([]);
+  });
+
+  it('parses coordination.other_bots: defer_if_present + custom logins', () => {
+    const cfg = loadConfigFromYaml(
+      'coordination:\n  other_bots: defer_if_present\n  other_bots_logins:\n    - my-internal-reviewer[bot]\n',
+    );
+    expect(cfg.coordination.other_bots).toBe('defer_if_present');
+    expect(cfg.coordination.other_bots_logins).toEqual(['my-internal-reviewer[bot]']);
+  });
+
+  it('rejects unknown coordination.other_bots mode', () => {
+    expect(() => loadConfigFromYaml('coordination:\n  other_bots: ask_first\n')).toThrow(
+      ConfigError,
+    );
+  });
 });
 
 describe('defaultConfig', () => {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -80,6 +80,32 @@ const IncrementalSchema = z
   })
   .strict();
 
+// `coordination.other_bots` (§22 #9 / v1.0 #48) controls coexistence with
+// other PR-review bots (`coderabbitai[bot]`, `qodo-merge[bot]`, etc.).
+//
+//   ignore (default)      — review independently; rely on per-finding
+//                           fingerprint dedup to avoid duplicate posts
+//                           against ourselves but make no attempt to
+//                           coordinate across bots.
+//   defer_if_present      — if any author in `other_bots_logins` (plus
+//                           the built-in allowlist in `known-bots.ts`)
+//                           has commented on the PR, post a single
+//                           skip-summary and exit without invoking the
+//                           agent loop. Useful when an org runs multiple
+//                           review bots in parallel and wants to avoid
+//                           comment thrash.
+//
+// `other_bots_logins` *adds to* the built-in list — operators don't lose
+// the defaults by overriding. To shrink the list, set the YAML key to
+// the desired full list and override the defaults at code level (not
+// supported via config).
+const CoordinationSchema = z
+  .object({
+    other_bots: z.enum(['ignore', 'defer_if_present']).default('ignore'),
+    other_bots_logins: z.array(z.string().min(1)).default([]),
+  })
+  .strict();
+
 // `extends: 'org'` (§10.2 layer 3) opts the repo into merging the
 // `<org>/.github/review-agent.yml` central config underneath this
 // file. Without `extends`, the org file is consulted only as a
@@ -101,6 +127,7 @@ export const ConfigSchema = z
     repo: RepoSchema.default({}),
     skills: z.array(z.string().min(1)).default([]),
     incremental: IncrementalSchema.default({}),
+    coordination: CoordinationSchema.default({}),
   })
   .strict();
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -36,6 +36,15 @@ job blocks merge if precision drops > 5 % or noise rate increases > 10 %
 versus the previous baseline. The v0.1 workflow runs the eval and uploads
 results; gating thresholds wire up alongside the baseline store in v0.2.
 
+## Baseline measurement
+
+`baseline.json` ships with `current_pass_rates.pending_measurement: true`
+until the operator records the first row per
+[`../../docs/eval/baseline-measurement.md`](../../docs/eval/baseline-measurement.md).
+Per-provider parity numbers feed
+[`../../docs/providers/parity-matrix.md`](../../docs/providers/parity-matrix.md)
+via `parity.json` + `pnpm matrix:write`.
+
 ## License
 
 Apache-2.0

--- a/packages/eval/baseline.json
+++ b/packages/eval/baseline.json
@@ -31,12 +31,20 @@
     "comment": "Cost per full corpus run on the cheapest / default model. Targets ≤ $1 / CI run on the cheapest provider model; Sonnet 4.6 is for the nightly precision-tracking workflow, not per-PR CI."
   },
   "current_pass_rates": {
-    "comment": "Recorded once the golden eval runs on a stable model build. v0.3 ships the corpus + harness; the first measured row lands in v0.3.1 alongside the model upgrade workflow.",
+    "comment": "v1.0 #45 schema: each entry represents one measurement run. Append a new entry per re-measurement (per minor release, per provider major bump). Numeric fields default null until the operator runs the eval per `docs/eval/baseline-measurement.md`. The pre-merge gate is: `red_team_bypass_count` MUST stay 0 even when the rest are null (no provider may regress on injection defence between releases).",
+    "pending_measurement": true,
+    "measurement_metadata": {
+      "recorded_at": null,
+      "model_id": null,
+      "git_sha": null,
+      "notes": "Awaiting first measured row per v1.0 #45. Procedure: docs/eval/baseline-measurement.md."
+    },
     "known_bug_precision": null,
     "known_bug_recall": null,
     "no_issue_false_positive_rate": null,
     "red_team_bypass_count": 0,
     "large_diff_max_wall_seconds": null,
     "multi_language_target_language_match_rate": null
-  }
+  },
+  "history": []
 }

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -9,6 +9,9 @@
     "eval": "promptfoo eval -c promptfooconfig.yaml",
     "eval:view": "promptfoo view",
     "eval:red-team": "promptfoo eval -c red-team.promptfooconfig.yaml",
+    "matrix": "tsx scripts/eval-matrix.ts",
+    "matrix:write": "tsx scripts/eval-matrix.ts --write",
+    "matrix:check": "tsx scripts/eval-matrix.ts --check",
     "validate:red-team": "tsx scripts/red-team-validate.ts",
     "validate:golden": "tsx scripts/golden-validate.ts",
     "verify:audit": "tsx scripts/verify-audit-chain.ts"

--- a/packages/eval/parity.json
+++ b/packages/eval/parity.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "description": "Per-provider parity numbers consumed by scripts/eval-matrix.ts to regenerate docs/providers/parity-matrix.md. Numeric fields default to null until the operator runs the corresponding `pnpm --filter @review-agent/eval matrix:run` measurement.",
+  "measured_at": null,
+  "anthropic_baseline_model": "claude-sonnet-4-6",
+  "providers": [
+    {
+      "id": "anthropic",
+      "label": "Anthropic (direct)",
+      "default_model": "claude-sonnet-4-6",
+      "features": {
+        "prompt_caching": "yes",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": 0
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "ZDR opt-in per Workspace; default 30-day retention"
+    },
+    {
+      "id": "openai",
+      "label": "OpenAI (direct)",
+      "default_model": "gpt-4o",
+      "features": {
+        "prompt_caching": "no",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "ZDR opt-in for Enterprise tier; default 30-day retention"
+    },
+    {
+      "id": "azure-openai",
+      "label": "Azure OpenAI",
+      "default_model": "gpt-4o",
+      "features": {
+        "prompt_caching": "no",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "no training-data use by default; abuse-monitoring 30 days unless opt-out"
+    },
+    {
+      "id": "google",
+      "label": "Google (Gemini direct)",
+      "default_model": "gemini-2.0-pro",
+      "features": {
+        "prompt_caching": "no",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "paid tier: no training-data use; default retention varies"
+    },
+    {
+      "id": "vertex",
+      "label": "Vertex AI",
+      "default_model": "claude-sonnet-4-6@anthropic",
+      "features": {
+        "prompt_caching": "yes",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "GCP customer data not used for model training"
+    },
+    {
+      "id": "bedrock",
+      "label": "AWS Bedrock",
+      "default_model": "anthropic.claude-sonnet-4-6-v1:0",
+      "features": {
+        "prompt_caching": "yes",
+        "structured_output": "json-schema",
+        "tool_calling": "yes"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "AWS customer data not used for model training; per-region storage"
+    },
+    {
+      "id": "openai-compatible",
+      "label": "OpenAI-compatible (Ollama / vLLM / OpenRouter / LM Studio)",
+      "default_model": "endpoint-dependent",
+      "features": {
+        "prompt_caching": "endpoint-dependent",
+        "structured_output": "endpoint-dependent",
+        "tool_calling": "endpoint-dependent"
+      },
+      "eval": {
+        "known_bug_precision": null,
+        "no_issue_false_positive_rate": null,
+        "noise_rate_delta_vs_baseline": null
+      },
+      "cost": {
+        "median_pr_usd": null,
+        "p95_latency_seconds": null
+      },
+      "data_retention": "endpoint-dependent (often local-only for self-hosted backends)"
+    }
+  ],
+  "footnote": "Numbers measured via the 60-fixture corpus (packages/eval/fixtures/golden/). Re-run via `pnpm --filter @review-agent/eval matrix:run -- <provider>` (one provider at a time so cost is bounded). Estimated full re-measurement cost across all paid providers: $5-8 per regen run."
+}

--- a/packages/eval/scripts/eval-matrix.ts
+++ b/packages/eval/scripts/eval-matrix.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Per-provider parity matrix renderer (v1.0 #46).
+//
+// Reads `packages/eval/parity.json`, renders a deterministic markdown
+// table to stdout, and (with --write) overwrites the matrix block in
+// `docs/providers/parity-matrix.md` between the
+// `<!-- BEGIN matrix -->` / `<!-- END matrix -->` markers.
+//
+// This script does NOT call any LLM. The actual eval measurement is
+// performed by `pnpm --filter @review-agent/eval eval` per provider;
+// the operator updates `parity.json` with the resulting numbers and
+// re-runs this script to refresh the published doc.
+//
+// Usage:
+//   tsx scripts/eval-matrix.ts                # print matrix to stdout
+//   tsx scripts/eval-matrix.ts --write        # overwrite parity-matrix.md
+//   tsx scripts/eval-matrix.ts --check        # exit non-zero if doc is stale
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PARITY_PATH = join(HERE, '..', 'parity.json');
+const DOC_PATH = join(HERE, '..', '..', '..', 'docs', 'providers', 'parity-matrix.md');
+const BEGIN_MARKER = '<!-- BEGIN matrix -->';
+const END_MARKER = '<!-- END matrix -->';
+
+const FeatureValueSchema = z.union([
+  z.literal('yes'),
+  z.literal('no'),
+  z.literal('json-schema'),
+  z.literal('tool-fallback'),
+  z.literal('endpoint-dependent'),
+]);
+
+const ProviderSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  default_model: z.string().min(1),
+  features: z.object({
+    prompt_caching: FeatureValueSchema,
+    structured_output: FeatureValueSchema,
+    tool_calling: FeatureValueSchema,
+  }),
+  eval: z.object({
+    known_bug_precision: z.number().nullable(),
+    no_issue_false_positive_rate: z.number().nullable(),
+    noise_rate_delta_vs_baseline: z.number().nullable(),
+  }),
+  cost: z.object({
+    median_pr_usd: z.number().nullable(),
+    p95_latency_seconds: z.number().nullable(),
+  }),
+  data_retention: z.string().min(1),
+});
+
+const ParitySchema = z.object({
+  version: z.literal(1),
+  measured_at: z.string().nullable(),
+  anthropic_baseline_model: z.string().min(1),
+  providers: z.array(ProviderSchema),
+  footnote: z.string().min(1),
+});
+
+type Parity = z.infer<typeof ParitySchema>;
+
+function fmt(value: number | null, suffix = ''): string {
+  if (value === null || value === undefined) return '—';
+  return `${value}${suffix}`;
+}
+
+function fmtDelta(value: number | null): string {
+  if (value === null || value === undefined) return '—';
+  if (value === 0) return 'baseline';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}`;
+}
+
+function renderMatrix(parity: Parity): string {
+  const measuredAt = parity.measured_at ?? 'not yet measured';
+  const lines: string[] = [];
+  lines.push(
+    `_Numbers measured: **${measuredAt}**. Baseline: \`${parity.anthropic_baseline_model}\`. See [packages/eval/parity.json](../../packages/eval/parity.json) for source data._`,
+  );
+  lines.push('');
+  lines.push(
+    '| Provider | Default model | Prompt caching | Structured output | Tool calling | Precision | FP rate | Noise Δ vs baseline | Median PR cost (USD) | p95 latency (s) | Data retention |',
+  );
+  lines.push('|---|---|---|---|---|---|---|---|---|---|---|');
+  for (const p of parity.providers) {
+    lines.push(
+      `| ${p.label} | \`${p.default_model}\` | ${p.features.prompt_caching} | ${p.features.structured_output} | ${p.features.tool_calling} | ${fmt(p.eval.known_bug_precision)} | ${fmt(p.eval.no_issue_false_positive_rate)} | ${fmtDelta(p.eval.noise_rate_delta_vs_baseline)} | ${fmt(p.cost.median_pr_usd)} | ${fmt(p.cost.p95_latency_seconds)} | ${p.data_retention} |`,
+    );
+  }
+  lines.push('');
+  lines.push(parity.footnote);
+  return lines.join('\n');
+}
+
+async function loadParity(): Promise<Parity> {
+  const raw = await readFile(PARITY_PATH, 'utf8');
+  return ParitySchema.parse(JSON.parse(raw));
+}
+
+function replaceMatrixBlock(doc: string, matrix: string): string {
+  const begin = doc.indexOf(BEGIN_MARKER);
+  const end = doc.indexOf(END_MARKER);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(
+      `Markers ${BEGIN_MARKER} / ${END_MARKER} not found (or out of order) in ${DOC_PATH}.`,
+    );
+  }
+  const head = doc.slice(0, begin + BEGIN_MARKER.length);
+  const tail = doc.slice(end);
+  return `${head}\n${matrix}\n${tail}`;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const parity = await loadParity();
+  const matrix = renderMatrix(parity);
+
+  if (args.includes('--check')) {
+    const doc = await readFile(DOC_PATH, 'utf8');
+    const expected = replaceMatrixBlock(doc, matrix);
+    if (doc !== expected) {
+      process.stderr.write(
+        `parity-matrix.md is stale relative to packages/eval/parity.json.\n` +
+          'Re-run: tsx packages/eval/scripts/eval-matrix.ts --write\n',
+      );
+      process.exit(1);
+    }
+    process.stdout.write('OK: parity-matrix.md is up to date.\n');
+    return;
+  }
+
+  if (args.includes('--write')) {
+    const doc = await readFile(DOC_PATH, 'utf8');
+    const updated = replaceMatrixBlock(doc, matrix);
+    await writeFile(DOC_PATH, updated, 'utf8');
+    process.stdout.write(`Wrote ${DOC_PATH}\n`);
+    return;
+  }
+
+  process.stdout.write(`${matrix}\n`);
+}
+
+void main();

--- a/packages/runner/src/coordination.test.ts
+++ b/packages/runner/src/coordination.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { decideCoordination, renderDeferralSummary } from './coordination.js';
+
+describe('decideCoordination', () => {
+  it('returns proceed when mode is ignore even if a known bot is present', () => {
+    const decision = decideCoordination({
+      mode: 'ignore',
+      botLogins: ['coderabbitai[bot]'],
+      existingCommentAuthors: ['coderabbitai[bot]', 'human-reviewer'],
+    });
+    expect(decision).toEqual({ action: 'proceed' });
+  });
+
+  it('defers when a known bot has commented and mode is defer_if_present', () => {
+    const decision = decideCoordination({
+      mode: 'defer_if_present',
+      botLogins: ['coderabbitai[bot]', 'qodo-merge[bot]'],
+      existingCommentAuthors: ['human-reviewer', 'coderabbitai[bot]'],
+    });
+    expect(decision).toEqual({ action: 'defer', bot: 'coderabbitai[bot]' });
+  });
+
+  it('returns proceed when defer_if_present but no matching bot found', () => {
+    const decision = decideCoordination({
+      mode: 'defer_if_present',
+      botLogins: ['coderabbitai[bot]'],
+      existingCommentAuthors: ['human-reviewer', 'github-actions[bot]'],
+    });
+    expect(decision).toEqual({ action: 'proceed' });
+  });
+
+  it('matches only on exact login (no partial / case-insensitive)', () => {
+    // Substring or case-insensitive matches would falsely trip on a
+    // human reviewer named `coderabbit-fan`.
+    const decision = decideCoordination({
+      mode: 'defer_if_present',
+      botLogins: ['coderabbitai[bot]'],
+      existingCommentAuthors: ['CodeRabbitAI[bot]', 'coderabbit-fan', 'coderabbitai'],
+    });
+    expect(decision).toEqual({ action: 'proceed' });
+  });
+
+  it('honours operator-supplied additional logins via the merged botLogins list', () => {
+    // The wiring layer is responsible for unioning the built-in allowlist
+    // with `coordination.other_bots_logins`. This test confirms the
+    // detection function uses the full list as-is — i.e. extension works.
+    const decision = decideCoordination({
+      mode: 'defer_if_present',
+      botLogins: ['coderabbitai[bot]', 'acme-internal-reviewer[bot]'],
+      existingCommentAuthors: ['acme-internal-reviewer[bot]'],
+    });
+    expect(decision).toEqual({ action: 'defer', bot: 'acme-internal-reviewer[bot]' });
+  });
+
+  it('returns proceed against an empty author list', () => {
+    expect(
+      decideCoordination({
+        mode: 'defer_if_present',
+        botLogins: ['coderabbitai[bot]'],
+        existingCommentAuthors: [],
+      }),
+    ).toEqual({ action: 'proceed' });
+  });
+
+  it('returns proceed against an empty bot list (no known reviewers configured)', () => {
+    expect(
+      decideCoordination({
+        mode: 'defer_if_present',
+        botLogins: [],
+        existingCommentAuthors: ['coderabbitai[bot]'],
+      }),
+    ).toEqual({ action: 'proceed' });
+  });
+});
+
+describe('renderDeferralSummary', () => {
+  it('mentions the detected bot login by name', () => {
+    const body = renderDeferralSummary('coderabbitai[bot]');
+    expect(body).toContain('coderabbitai[bot]');
+    expect(body).toContain('skipped');
+    expect(body).toContain('coordination.other_bots');
+  });
+});

--- a/packages/runner/src/coordination.ts
+++ b/packages/runner/src/coordination.ts
@@ -1,0 +1,52 @@
+// Multi-bot coordination policy (spec §22 #9 / v1.0 #48).
+//
+// `decideCoordination` is a pure function: it takes the operator's
+// `coordination.*` configuration plus the PR's existing comment
+// authors, and returns whether this run should defer to another
+// review bot. The action / server / CLI wrappers are responsible for
+// (a) gathering the comment authors via the VCS adapter and (b)
+// posting the skip-summary comment when `defer` is true.
+//
+// `runner` deliberately doesn't import from `@review-agent/config` —
+// the static allowlist lives there (it's operator-facing); the
+// caller passes the union of the built-in list and any operator
+// override (`coordination.other_bots_logins`) in via `botLogins`.
+// Match is on exact GitHub login (the `[bot]`-suffix is included)
+// because partial matches risk false positives against human
+// reviewers and the platform adapter normalises to `c.user.login`.
+
+export const COORDINATION_MODES = ['ignore', 'defer_if_present'] as const;
+export type CoordinationMode = (typeof COORDINATION_MODES)[number];
+
+export type CoordinationDecisionInput = {
+  readonly mode: CoordinationMode;
+  readonly botLogins: ReadonlyArray<string>;
+  readonly existingCommentAuthors: ReadonlyArray<string>;
+};
+
+export type CoordinationDecision =
+  | { readonly action: 'proceed' }
+  | { readonly action: 'defer'; readonly bot: string };
+
+export function decideCoordination(input: CoordinationDecisionInput): CoordinationDecision {
+  if (input.mode === 'ignore') return { action: 'proceed' };
+  const detection = new Set(input.botLogins);
+  for (const author of input.existingCommentAuthors) {
+    if (detection.has(author)) return { action: 'defer', bot: author };
+  }
+  return { action: 'proceed' };
+}
+
+// Body for the single skip-summary comment posted when deferring.
+// Markdown formatted; the action wrapper passes this to
+// `vcs.postSummary(...)`. Kept here so the message stays close to
+// the policy code that produces it.
+export function renderDeferralSummary(bot: string): string {
+  return [
+    '### review-agent — skipped',
+    '',
+    `Detected an existing review by \`${bot}\`. \`coordination.other_bots\` is set to \`defer_if_present\`, so this run will not post additional comments.`,
+    '',
+    'To override, set `coordination.other_bots: ignore` in `.review-agent.yml` (or remove the key entirely — `ignore` is the default).',
+  ].join('\n');
+}

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,4 +1,12 @@
 export { runReview } from './agent.js';
+export {
+  COORDINATION_MODES,
+  type CoordinationDecision,
+  type CoordinationDecisionInput,
+  type CoordinationMode,
+  decideCoordination,
+  renderDeferralSummary,
+} from './coordination.js';
 export { createCostKillSwitch, type KillSwitchOpts } from './cost-kill-switch.js';
 export {
   assertDailyCapNotExceeded,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -83,6 +83,14 @@ in flight.
 `pg_try_advisory_lock(0xabba0001)` so a multi-worker fleet only deletes
 once per cycle. Use `pg_cron` instead in environments that support it.
 
+## Bot identity
+
+In Server mode comments are posted by `<your-app-name>[bot]`, the
+GitHub App's own actor. Name the App audit-readably (e.g.
+`acme-review` → `acme-review[bot]`). See
+[`docs/configuration/bot-identity.md`](../../docs/configuration/bot-identity.md)
+for the per-mode mapping and audit-trail recommendations.
+
 ## Security
 
 - Signature verification reads the **raw body** before JSON parse and uses

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -4,6 +4,17 @@
     "ReviewAgentConfig": {
       "type": "object",
       "properties": {
+        "extends": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "org"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "language": {
           "type": "string",
           "enum": [
@@ -239,6 +250,26 @@
             "enabled": {
               "type": "boolean",
               "default": true
+            }
+          },
+          "additionalProperties": false,
+          "default": {}
+        },
+        "coordination": {
+          "type": "object",
+          "properties": {
+            "other_bots": {
+              "type": "string",
+              "enum": ["ignore", "defer_if_present"],
+              "default": "ignore"
+            },
+            "other_bots_logins": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "default": []
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
## Summary

Closes all 9 v1.0 milestone issues (#43–#51) — the v1.0 release gate per `docs/roadmap.md`.

| # | Issue | Commit |
|---|---|---|
| #43 | UPGRADING.md + SemVer stability declaration | `d688f23` |
| #44 | Internal STRIDE threat-model walkthrough | `9dd245e` (drafted; awaits unaffiliated reviewer sign-off) |
| #45 | baseline.json measurement procedure | `44947f7` |
| #46 | Per-provider feature parity matrix + renderer | `44947f7` |
| #47 | Bot identity guidance per distribution mode | `9dd245e` |
| #48 | Multi-bot coordination policy (`coordination.other_bots`) | `a2e5628` |
| #49 | GHES compatibility statement (best-effort, no commitment) | `9dd245e` |
| #50 | `review-agent setup workspace` CLI | `0a2bb2c` |
| #51 | cosign skill attestation — wontfix rationale recorded | `9dd245e` |

## Highlights

- **#48 multi-bot coordination**: new `.review-agent.yml` field `coordination.other_bots: ignore | defer_if_present` plus `other_bots_logins` operator extension. Built-in detection: coderabbitai / qodo-merge / pr-agent-bot / bedrock-pr-reviewer. Architecture: detection logic in `runner/src/coordination.ts` (pure function, no `@review-agent/config` import — preserves package boundary), allowlist in `config/src/known-bots.ts`, action wrapper unions both lists. Inline-comment-only detection in v1.0 (summary-only bots documented as v1.x follow-up).
- **#50 setup workspace CLI**: `review-agent setup workspace` prints a manual checklist by default (workspace creation, ZDR enablement, monthly spend cap, workspace-scoped key); `--api` calls the Anthropic Admin API with `ANTHROPIC_ADMIN_KEY` (distinct from inference key, never logged in either success or error paths). Upfront notice that ZDR cannot be toggled via the Admin API.
- **#46 parity matrix**: `docs/providers/parity-matrix.md` driven by `packages/eval/parity.json` and `scripts/eval-matrix.ts` (--check / --write). Numbers are placeholder `null` until operator runs per-provider evals (~$5–8 per regen).
- **#43 UPGRADING.md**: SemVer commitment from v1.0+, public-API surface enumerated per package, internal-only surfaces (middleware internals, prompt strings, telemetry attribute names, Drizzle column names) explicitly excluded. Changesets policy added to `.github/CONTRIBUTING.md`.
- **#44 STRIDE walkthrough**: `docs/security/threat-model-review-2026-05.md` covers 6 STRIDE categories against the v0.3/v1.0 surface. 0 critical/high; 4 informational findings. **Awaiting unaffiliated reviewer sign-off — that gate is the only remaining blocker for issue #44 close.**

## Verification

- `pnpm typecheck` — green across all 12 workspace packages
- `pnpm lint` — green (Biome 2.x, 318 files)
- `pnpm test` — green (40 cli + 13 action + 111 runner + 60 server + 69 platform-github + 40 config + ...; ~400 tests total)
- `pnpm build` — green (ESM + CJS + .d.ts per public package)
- `pnpm --filter @review-agent/eval matrix:check` — green (parity-matrix.md in sync with parity.json)

## Code review

Three parallel reviewer agents flagged 1 critical (incorrect file paths in threat-model doc) + 5 important issues; all addressed in the final commits before push.

## Test plan

- [ ] CI green (typecheck + lint + test + build + eval matrix:check)
- [ ] `review-agent setup workspace` (default mode) prints the manual checklist with deep links
- [ ] `coordination.other_bots: defer_if_present` + a known bot comment → review-agent posts the skip-summary and exits without invoking the agent loop
- [ ] `coordination.other_bots: ignore` (or omitted) → no extra `getExistingComments` API call (short-circuit invariant)
- [ ] `pnpm config schema` output matches the committed `schema/v1.json`
- [ ] (manual, post-merge) issue #44 stays open until unaffiliated reviewer signs off `docs/security/threat-model-review-2026-05.md`

## Out of scope (deferred to v1.x or operator action)

- First measured eval baseline (operator runs `pnpm --filter @review-agent/eval eval` per provider; this PR ships the procedure + scaffolding only)
- Summary-only bot detection in `coordination` (would require adding `issues.listComments` to the VCS interface)
- cosign attestation infrastructure (#51 wontfix; revisit when first first-party `@review-agent/skill-*` ships)
- v1.0 git tag (separate release PR after issue #44 sign-off lands)
