### PR TITLE
feat: v1.1 CodeCommit support (#73-#80) + multi-agent audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,28 @@ What each block does:
 
 In **Server mode** (Hono webhook → SQS → worker) the same runner is invoked from `packages/server/src/worker.ts`. The worker provisions a per-job ephemeral workspace via `provisionWorkspace` (strategy: `contents-api` for Lambda, `sparse-clone` when `git` is available); everything downstream of "Workspace" in the diagram is identical.
 
+## Supported VCS platforms
+
+| Platform | Modes | Status | Notes |
+|---|---|---|---|
+| **GitHub** (`platform-github`) | GitHub Action / Server (webhook → SQS) / CLI | ✅ Full support | Default. Hidden-state-comment dedup + `REQUEST_CHANGES` mapping. |
+| **GitHub Enterprise Server** | Server / CLI | ✅ Supported | Uses the same Octokit path. See [`docs/deployment/ghes.md`](./docs/deployment/ghes.md). |
+| **AWS CodeCommit** (`platform-codecommit`) | CLI / Server (manual trigger) | ⚠️ Partial | Adapter ships and posts reviews. Automatic event ingestion (SNS → SQS) and CLI `--platform codecommit` flag are tracked in [#73](https://github.com/almondoo/review-agent/issues/73) / [#75](https://github.com/almondoo/review-agent/issues/75). Postgres-canonical state (no hidden-comment markers — see spec §12.1.1). |
+
+GitLab / Bitbucket adapters are out of scope for v1.x (spec §1.2).
+
 ## Repo layout
 
 ```
 packages/
-  core/              # types, schemas, fingerprinting (no I/O)
-  llm/               # Vercel AI SDK provider adapters + retry/error mapping
-  config/            # zod-typed YAML loader, env-merge, JSON schema export
-  platform-github/   # VCS impl: clone, diff, comments, hidden state
-  runner/            # agent loop, tools, prompts, gitleaks, skill loader
-  action/            # GitHub Action wrapper (entry point)
-  eval/              # promptfoo regression suite + golden PR fixtures
+  core/                # types, schemas, fingerprinting (no I/O)
+  llm/                 # Vercel AI SDK provider adapters + retry/error mapping
+  config/              # zod-typed YAML loader, env-merge, JSON schema export
+  platform-github/     # VCS impl: clone, diff, comments, hidden state (GitHub)
+  platform-codecommit/ # VCS impl: AWS CodeCommit (Postgres-canonical state)
+  runner/              # agent loop, tools, prompts, gitleaks, skill loader
+  action/              # GitHub Action wrapper (entry point)
+  eval/                # promptfoo regression suite + golden PR fixtures
 ```
 
 See [`docs/specs/review-agent-spec.md`](./docs/specs/review-agent-spec.md)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ In **Server mode** (Hono webhook → SQS → worker) the same runner is invoked 
 | **GitHub Enterprise Server** | Server / CLI | ✅ Supported | Uses the same Octokit path. See [`docs/deployment/ghes.md`](./docs/deployment/ghes.md). |
 | **AWS CodeCommit** (`platform-codecommit`) | CLI / Server (manual trigger) | ⚠️ Partial | Adapter ships and posts reviews. Automatic event ingestion (SNS → SQS) and CLI `--platform codecommit` flag are tracked in [#73](https://github.com/almondoo/review-agent/issues/73) / [#75](https://github.com/almondoo/review-agent/issues/75). Postgres-canonical state (no hidden-comment markers — see spec §12.1.1). |
 
+> **CodeCommit data-durability warning.** CodeCommit installations store
+> review state in Postgres only — the platform side has no canonical
+> copy. If Postgres is lost, the next review on every open PR is a full
+> re-run. Plan backups (RDS PITR / Aurora snapshots) and follow the
+> dedicated runbook at
+> [`docs/operations/codecommit-disaster-recovery.md`](./docs/operations/codecommit-disaster-recovery.md)
+> before going to production.
+
 GitLab / Bitbucket adapters are out of scope for v1.x (spec §1.2).
 
 ## Repo layout

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -403,9 +403,12 @@ SELECT COUNT(*) AS recovered FROM review_state WHERE installation_id = 123;
 
 - For multi-repo installations, rerun the command per repo. Multi-repo
   iteration is a v0.4 follow-up.
-- **CodeCommit installations cannot recover state.** They use
-  Postgres-only state per §12.1.1 — the next webhook on every PR is a
-  full re-review. Document this in the customer comms.
+- **CodeCommit installations cannot recover state via this command.**
+  They use Postgres-only state per §12.1.1 — the platform side has no
+  canonical copy. Follow the dedicated CodeCommit runbook at
+  [`docs/operations/codecommit-disaster-recovery.md`](./docs/operations/codecommit-disaster-recovery.md)
+  to plan backups, restore Postgres, verify the audit-log chain, and
+  drive the manual re-review pass on every open PR.
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -186,6 +186,14 @@ flowchart TD
 | **GitHub Enterprise Server** | Server / CLI | ✅ 対応 | 同じ Octokit 経路を使用。[`docs/deployment/ghes.md`](./deployment/ghes.md) 参照。 |
 | **AWS CodeCommit** (`platform-codecommit`) | CLI / Server（手動トリガー） | ⚠️ 部分対応 | アダプタ実装済みでレビューは投稿可能。自動イベント受信（SNS → SQS）と CLI `--platform codecommit` フラグは [#73](https://github.com/almondoo/review-agent/issues/73) / [#75](https://github.com/almondoo/review-agent/issues/75) で対応中。状態は Postgres canonical（隠しコメントマーカーなし — spec §12.1.1）。 |
 
+> **CodeCommit のデータ耐久性に関する警告**: CodeCommit インストールは
+> レビュー状態を Postgres のみに保存し、プラットフォーム側には canonical
+> なコピーが存在しません。Postgres を失うと、開いている全 PR の次回レビュー
+> はフル再実行になります。本番投入前に RDS PITR / Aurora snapshot で
+> バックアップを計画し、専用 runbook
+> [`docs/operations/codecommit-disaster-recovery.md`](./operations/codecommit-disaster-recovery.md)
+> を参照してください。
+
 GitLab / Bitbucket アダプタは v1.x のスコープ外です（spec §1.2）。
 
 ## リポジトリ構成

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -178,17 +178,28 @@ flowchart TD
 （strategy: Lambda は `contents-api`、`git` 利用可なら `sparse-clone`）で
 ジョブ単位の一時 workspace を用意する。図の "Workspace" 以降は完全に同一。
 
+## 対応 VCS プラットフォーム
+
+| プラットフォーム | モード | ステータス | 備考 |
+|---|---|---|---|
+| **GitHub** (`platform-github`) | GitHub Action / Server (webhook → SQS) / CLI | ✅ フル対応 | デフォルト。隠し state コメントによる重複排除、`REQUEST_CHANGES` マッピング。 |
+| **GitHub Enterprise Server** | Server / CLI | ✅ 対応 | 同じ Octokit 経路を使用。[`docs/deployment/ghes.md`](./deployment/ghes.md) 参照。 |
+| **AWS CodeCommit** (`platform-codecommit`) | CLI / Server（手動トリガー） | ⚠️ 部分対応 | アダプタ実装済みでレビューは投稿可能。自動イベント受信（SNS → SQS）と CLI `--platform codecommit` フラグは [#73](https://github.com/almondoo/review-agent/issues/73) / [#75](https://github.com/almondoo/review-agent/issues/75) で対応中。状態は Postgres canonical（隠しコメントマーカーなし — spec §12.1.1）。 |
+
+GitLab / Bitbucket アダプタは v1.x のスコープ外です（spec §1.2）。
+
 ## リポジトリ構成
 
 ```
 packages/
-  core/              # 型・スキーマ・fingerprint（I/O なし）
-  llm/               # Vercel AI SDK provider adapter + retry/error mapping
-  config/            # zod 型付き YAML loader、env マージ、JSON schema 出力
-  platform-github/   # VCS 実装: clone / diff / コメント / 隠し state
-  runner/            # エージェントループ、ツール、プロンプト、gitleaks、skill loader
-  action/            # GitHub Action ラッパー（エントリポイント）
-  eval/              # promptfoo 回帰スイート + golden PR fixture
+  core/                # 型・スキーマ・fingerprint（I/O なし）
+  llm/                 # Vercel AI SDK provider adapter + retry/error mapping
+  config/              # zod 型付き YAML loader、env マージ、JSON schema 出力
+  platform-github/     # VCS 実装: clone / diff / コメント / 隠し state (GitHub)
+  platform-codecommit/ # VCS 実装: AWS CodeCommit（Postgres canonical state）
+  runner/              # エージェントループ、ツール、プロンプト、gitleaks、skill loader
+  action/              # GitHub Action ラッパー（エントリポイント）
+  eval/                # promptfoo 回帰スイート + golden PR fixture
 ```
 
 完全な仕様は [`docs/specs/review-agent-spec.md`](./specs/review-agent-spec.md)、

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -501,11 +501,45 @@ https://<receiver>/webhook/codecommit
 ```
 
 The receiver verifies the SNS message signature against the
-`SigningCertURL` (host-allowlisted to `*.amazonaws.com`), confirms
-new subscriptions by fetching the `SubscribeURL`, and dedups on
-`MessageId` using the same `webhook_deliveries` table as the GitHub
-path. PR open / source-branch-update / comment-with-`@review-agent`
-events enqueue a `JobMessage` with `prRef.platform = 'codecommit'`.
+`SigningCertURL` (host-allowlisted to
+`sns.<region>.amazonaws.com`), confirms new subscriptions by
+fetching the `SubscribeURL`, and dedups on `sns:<MessageId>` in the
+same `webhook_deliveries` table as the GitHub path (the `sns:`
+prefix prevents probabilistic UUID collisions with GitHub's
+`X-GitHub-Delivery` — SEC-3 audit fix). PR open / source-branch-
+update / comment-with-`@review-agent` events enqueue a `JobMessage`
+with `prRef.platform = 'codecommit'`.
+
+**Required environment**: `REVIEW_AGENT_SNS_TOPIC_ARNS` — a comma-
+separated allowlist of SNS Topic ARNs the receiver will accept
+deliveries from. The receiver is **fail-closed** (SEC-1 audit fix):
+if this variable is unset or empty, every delivery to
+`/webhook/codecommit` is rejected with `403`. The SNS message
+signature only proves "some AWS SNS topic in some account signed
+this envelope" — an attacker who owns an SNS topic in *any* AWS
+account could otherwise deliver a `SubscriptionConfirmation` to
+this endpoint, have it auto-confirmed, and then deliver forged
+`commentOnPullRequest` notifications. The allowlist closes that gap
+by pinning the receiver to topics the operator explicitly trusts.
+
+```bash
+# Single topic:
+REVIEW_AGENT_SNS_TOPIC_ARNS=arn:aws:sns:us-east-1:111111111111:review-agent-codecommit
+
+# Multiple topics (e.g. cross-region):
+REVIEW_AGENT_SNS_TOPIC_ARNS=arn:aws:sns:us-east-1:111111111111:t1,arn:aws:sns:us-west-2:111111111111:t2
+```
+
+**`installationId` semantics**: the receiver derives the
+`JobMessage.installationId` from the EventBridge envelope's
+`account` field (the 12-digit AWS account ID). This is stable
+across deliveries, numeric (passes the
+`packages/db/src/tenancy.ts` `/^\d+$/` guard), fits in `bigint`,
+and serves as a natural per-tenant key — one AWS account is one
+operator tenant. Multiple repos in the same account share the
+`installationId`; per-PR keying via `review_state.id =
+${owner}/${repo}#${number}` continues to differentiate them.
+Flat (non-EventBridge) deliveries lack `account` and are rejected.
 
 Illustrative Terraform sketch (not runnable as-is — wire the actual
 SNS / EventBridge resource names into your stack):

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -476,7 +476,10 @@ Additional patterns specific to this narrative:
   CodeCommit lives **only in Postgres** (spec §12.1.1), so the DR story
   becomes critical: there is no equivalent of the GitHub
   `recover sync-state-from-hidden-comment` path. Take regular RDS
-  snapshots and treat the DB as a hard dependency.
+  snapshots and treat the DB as a hard dependency. The full operator
+  procedure (RPO/RTO targets, restore steps, audit-chain reverify,
+  manual re-review pass) lives at
+  [`docs/operations/codecommit-disaster-recovery.md`](../operations/codecommit-disaster-recovery.md).
 
 ## 16. References
 

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -481,6 +481,68 @@ Additional patterns specific to this narrative:
   manual re-review pass) lives at
   [`docs/operations/codecommit-disaster-recovery.md`](../operations/codecommit-disaster-recovery.md).
 
+### EventBridge → SNS → `/webhook/codecommit`
+
+For CodeCommit installs, the receiver exposes a second endpoint
+`POST /webhook/codecommit` that consumes the SNS HTTPS subscription
+envelope. The intended wiring is:
+
+```
+CodeCommit repo
+   │
+   ▼  (default event bus, source: aws.codecommit)
+EventBridge rule
+   │
+   ▼  (target: SNS topic)
+SNS topic (review-agent-codecommit)
+   │
+   ▼  (HTTPS subscription, signature v2)
+https://<receiver>/webhook/codecommit
+```
+
+The receiver verifies the SNS message signature against the
+`SigningCertURL` (host-allowlisted to `*.amazonaws.com`), confirms
+new subscriptions by fetching the `SubscribeURL`, and dedups on
+`MessageId` using the same `webhook_deliveries` table as the GitHub
+path. PR open / source-branch-update / comment-with-`@review-agent`
+events enqueue a `JobMessage` with `prRef.platform = 'codecommit'`.
+
+Illustrative Terraform sketch (not runnable as-is — wire the actual
+SNS / EventBridge resource names into your stack):
+
+```hcl
+resource "aws_sns_topic" "codecommit" {
+  name = "review-agent-codecommit"
+}
+
+resource "aws_cloudwatch_event_rule" "codecommit_pr" {
+  name        = "review-agent-codecommit-pr"
+  description = "Forward CodeCommit PR + comment events to the review-agent receiver"
+  event_pattern = jsonencode({
+    source        = ["aws.codecommit"]
+    "detail-type" = ["CodeCommit Pull Request State Change", "CodeCommit Comment on Pull Request"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "codecommit_to_sns" {
+  rule = aws_cloudwatch_event_rule.codecommit_pr.name
+  arn  = aws_sns_topic.codecommit.arn
+}
+
+resource "aws_sns_topic_subscription" "receiver" {
+  topic_arn = aws_sns_topic.codecommit.arn
+  protocol  = "https"
+  endpoint  = "https://${var.receiver_host}/webhook/codecommit"
+  # SNS will POST a SubscriptionConfirmation; the receiver auto-confirms
+  # by fetching the SubscribeURL inside the message envelope.
+}
+```
+
+If the receiver runs behind API Gateway HTTP API (the default
+deployment in this doc), no additional auth header is needed: SNS
+signs every envelope and the receiver rejects anything that fails
+verification with `401`.
+
 ## 16. References
 
 - Spec §15.1 — AWS Lambda + Terraform reference deploy.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -83,6 +83,25 @@ Notes:
   `--platform codecommit` short-circuits with an informative message
   (CodeCommit treats Postgres as the canonical state).
 
+#### Approval-state mapping (opt-in)
+
+By default the CLI does **not** mutate the CodeCommit pull-request approval
+state when posting a review — it only writes inline comments and the
+Postgres-backed state record. To let the agent map a request-changes
+verdict onto `REVOKE` and an approval onto `APPROVE`, opt in via
+`.review-agent.yml`:
+
+```yaml
+codecommit:
+  approvalState: managed   # default: off
+```
+
+The CLI threads this value into `createCodecommitVCS({ approvalState })`
+on every run, so the behaviour matches the server. See
+[`packages/platform-codecommit/README.md`](../../packages/platform-codecommit/README.md#approval-state-mapping-74)
+for the full mapping table and the IAM permissions required
+(`codecommit:UpdatePullRequestApprovalState`).
+
 The dry-run summary lists each generated comment as
 `[severity] path:line — first line of body` plus the model, tokens, cost,
 and the run summary. Use `--post` only after you've reviewed the dry-run.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -28,6 +28,7 @@ You can now invoke `review-agent` from anywhere on your `PATH`.
 | `REVIEW_AGENT_PROVIDER` / `REVIEW_AGENT_MODEL` | `review` (override) | Switch driver (`openai`, `azure-openai`, ...) |
 | `REVIEW_AGENT_LANGUAGE` | `review` (override) | Output language (BCP-47) |
 | `REVIEW_AGENT_MAX_USD_PER_PR` | `review` (override) | Hard ceiling on per-run LLM spend |
+| `AWS_REGION` / `AWS_PROFILE` | `review --platform codecommit` | Standard AWS SDK credential chain (also picks up IRSA / EC2 metadata) |
 
 Spec §8.3 + Appendix B has the full list. A PAT is fine for local use.
 For org-scale or shared-team use, deploy the Action or webhook server
@@ -42,6 +43,7 @@ Runs a full review against the named PR. Flags:
 | Flag | Default | Notes |
 |---|---|---|
 | `--config <path>` | `.review-agent.yml` | Optional. Falls back to defaults when missing. |
+| `--platform <github\|codecommit>` | `github` | VCS platform. `codecommit` reuses `--repo` as a bare repository name and authenticates via the AWS credential provider chain. |
 | `--lang <code>` | (config) | BCP-47 — same set as `REVIEW_AGENT_LANGUAGE` |
 | `--profile <chill\|assertive>` | (config) | Reviewer style |
 | `--cost-cap-usd <usd>` | (config `cost.max_usd_per_pr`) | Hard ceiling on this run |
@@ -58,6 +60,28 @@ review-agent review --repo owner/repo --pr 42 --post
 review-agent review --repo owner/repo --pr 42 \
   --lang ja-JP --profile assertive --cost-cap-usd 0.50
 ```
+
+#### CodeCommit example
+
+CodeCommit auth piggybacks on the AWS credential provider chain — no token
+flag, no extra wiring. Set `AWS_REGION` (and any of `AWS_PROFILE`, IRSA,
+EC2 metadata, etc.) and pass `--platform codecommit` with the bare
+repository name as `--repo`:
+
+```bash
+AWS_REGION=us-east-1 AWS_PROFILE=my-profile \
+  review-agent review --pr 42 --platform codecommit --repo demo-repo
+```
+
+Notes:
+
+- `--repo` for CodeCommit is the **repository name** (no `owner/` prefix).
+- The CLI does not accept an AWS access key directly — use the standard
+  SDK environment variables or named profile so the same wiring works
+  for `aws` CLI and other tooling.
+- `recover sync-state` is GitHub-only on purpose; passing
+  `--platform codecommit` short-circuits with an informative message
+  (CodeCommit treats Postgres as the canonical state).
 
 The dry-run summary lists each generated comment as
 `[severity] path:line — first line of body` plus the model, tokens, cost,

--- a/docs/operations/codecommit-disaster-recovery.md
+++ b/docs/operations/codecommit-disaster-recovery.md
@@ -1,0 +1,268 @@
+# CodeCommit disaster recovery — Postgres-canonical state
+
+CodeCommit installations of `review-agent` cannot recover review state
+from the platform itself. Unlike GitHub — where the hidden
+`<!-- review-agent-state: ... -->` marker on the summary comment is the
+canonical store — CodeCommit's HTML escaping mangles those markers, so
+the adapter writes state to Postgres **only** (spec §5.2.1, §12.1.1;
+`packages/platform-codecommit/src/adapter.ts:229-234`).
+
+That means: **if Postgres is lost, the platform side has no canonical
+copy.** This runbook is the operator-facing procedure to (a) plan for
+that loss with sufficient backups, and (b) recover the agent into a
+working state after a disaster.
+
+If you operate GitHub installations only, see §8.6.6 in
+[`/SECURITY.md`](../../SECURITY.md) — `review-agent recover sync-state`
+covers GitHub's recovery path automatically.
+
+---
+
+## 1. Recovery objectives (RPO / RTO targets)
+
+Pick a tier per installation; document in your operations handbook
+alongside the rest of your DB DR plan.
+
+| Tier | Workload                              | RPO  | RTO  | Backup strategy                                                                                                                                                                               |
+|------|---------------------------------------|------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| A    | Multi-tenant, paying customers        | ≤ 5 min | ≤ 1 h | RDS / Aurora point-in-time recovery (PITR) with 35-day retention; cross-region read replica.                                                                                                  |
+| B    | Single-tenant, internal team          | ≤ 1 h | ≤ 4 h | Daily automated snapshot + 7-day PITR retention.                                                                                                                                              |
+| C    | Demo / non-prod                       | ≤ 24 h | ≤ 24 h | Daily logical dump (`pg_dump`) to versioned object storage.                                                                                                                                  |
+
+**These numbers are not policy commitments from this project** — they
+are the planning baseline. Tier-A users typically need to commit to
+tighter numbers in their own SLAs.
+
+The three tables that matter for recovery are:
+
+| Table          | Why it matters on CodeCommit                                                                                                                                                                                                                                                                                                                                                       |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `review_state` | Sole source of truth for incremental-review memory (spec §12.1.1). Loss → every open PR's next review is full-cost, and previously-posted comments will be re-emitted unless dedup catches them by fingerprint (it usually will, but the re-review is paid for in full).                                                                                                          |
+| `audit_log`    | HMAC-chained, immutable evidence trail (spec §17, `packages/db/src/audit-log.ts`). Loss breaks the chain — the verifier (`review-agent recover audit-verify`) will report "BREAK at row N" until the chain restarts from a fresh genesis row.                                                                                                                                       |
+| `cost_ledger`  | Per-LLM-call spend by installation (spec §13.4). Loss removes the basis for cost-cap enforcement reconciliation and operator billing dashboards.                                                                                                                                                                                                                                   |
+
+Back up all three. Cost-ledger snapshots are particularly valuable for
+recovery because they let you reconstruct the model / token / dollar
+attribution for the affected window without re-running the LLM.
+
+---
+
+## 2. `recover sync-state` does NOT apply to CodeCommit
+
+On GitHub:
+
+```bash
+review-agent recover sync-state --repo owner/name --installation 123
+```
+
+walks every open PR, reads the hidden state comment, and rehydrates the
+`review_state` row from the canonical comment payload.
+
+On CodeCommit this command **does not exist** and there is no equivalent.
+Why:
+
+1. CodeCommit's `PostCommentForPullRequest` HTML-escapes the comment
+   body. The `<!-- ... -->` wrapper that GitHub renders as an HTML
+   comment is escaped to literal `&lt;!-- ... --&gt;` text on
+   CodeCommit, so the marker does not survive the round-trip.
+2. The adapter therefore writes a **plain-Markdown** summary comment
+   without the marker (spec §12.1.1, `adapter.ts` `postSummary`). There
+   is no canonical state to reconstruct from.
+3. `getStateComment()` returns `null` and `upsertStateComment()` is a
+   no-op (`adapter.ts:229-234`). The runner detects this and routes
+   read/write to Postgres via `createReviewStateMirror` in
+   `@review-agent/db`.
+
+Practical consequence: **after a Postgres loss on a CodeCommit
+installation, you have lost the platform-side incremental-review
+memory.** Plan accordingly (Tier-A users: take this seriously when
+choosing PITR retention).
+
+---
+
+## 3. Recovery procedure
+
+### Step 0 — Triage (before touching anything)
+
+1. Confirm the loss is real: connect with the migrations role and
+   `SELECT COUNT(*) FROM review_state;`. A clean `0` against an
+   installation you know has open reviews is the signal.
+2. Identify the affected installations. If multi-tenant, scope
+   subsequent work to one installation at a time.
+3. Decide whether to restore from backup (preferred when RPO is
+   acceptable) or to accept a full re-review (faster, costs the next
+   PR's full LLM spend).
+
+### Step 1 — Restore Postgres from the most recent backup
+
+The exact commands depend on your DB hosting. Examples:
+
+```bash
+# AWS RDS — point-in-time restore to a new instance.
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier review-agent-db \
+  --target-db-instance-identifier review-agent-db-restored \
+  --restore-time "$(date -u -v-1h +%FT%TZ)"
+
+# Aurora — PITR likewise:
+aws rds restore-db-cluster-to-point-in-time \
+  --source-db-cluster-identifier review-agent-aurora \
+  --db-cluster-identifier review-agent-aurora-restored \
+  --restore-to-time "$(date -u -v-1h +%FT%TZ)"
+
+# Self-host (docker / k8s) — restore from logical dump.
+psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+pg_restore --no-owner --dbname "$DATABASE_URL" /backups/review-agent.YYYY-MM-DD.dump
+```
+
+After the restore completes, point the worker at the restored DB:
+
+```bash
+# Lambda: bump the env-var to force a cold start that re-reads the
+# DATABASE_URL secret.
+aws lambda update-function-configuration \
+  --function-name review-agent-worker \
+  --environment "Variables={ROTATED_AT=$(date +%s)}"
+```
+
+### Step 2 — Verify the audit-log chain
+
+Run the HMAC chain verifier against the restored DB:
+
+```bash
+review-agent recover audit-verify
+#  → "OK: 1234 rows verified" if the chain is intact.
+#  → "BREAK at row N (prev_hash mismatch)" if a partial restore landed.
+```
+
+If the chain breaks, you have three options:
+
+1. **Restore from an older backup that pre-dates the break.** Loses the
+   most recent events but keeps the chain intact.
+2. **Reset the chain.** Mark the break point in your operations log,
+   then truncate `audit_log` and let the next run write a new genesis
+   row. SOC2 evidence for the lost window becomes whatever you can
+   reconstruct from CloudTrail + LLM-provider dashboards.
+3. **Continue with a known break.** Acceptable only for non-prod /
+   Tier-C.
+
+### Step 3 — Re-import historical audit-log snapshots (optional)
+
+If you keep periodic `audit_log` snapshots (e.g. a daily dump to
+object storage), you can re-import them to fill gaps left by the
+restore. The snapshots **must** include `prev_hash` and `row_hash`
+columns so the chain replays bit-for-bit.
+
+```bash
+# Example: snapshots stored as compressed COPY-format text in S3.
+aws s3 cp s3://your-bucket/audit-log/2026-05-10.copy.gz - \
+  | gunzip - \
+  | psql "$DATABASE_URL" -c "COPY audit_log FROM STDIN"
+
+# Re-verify.
+review-agent recover audit-verify
+```
+
+If the snapshot is from before the most recent restore point, expect
+the verifier to report a duplicate-row error rather than a chain
+break — `(row_hash)` is the primary key on `audit_log`. Resolve by
+deduplicating against the live table before COPY.
+
+### Step 4 — Manual re-review of open PRs
+
+Even with a perfect restore, the gap between the restore point and
+"now" is unreviewed. Walk every open CodeCommit PR in the affected
+installation:
+
+```bash
+# List open PRs (uses the IAM role on the worker host).
+aws codecommit list-pull-requests \
+  --repository-names <repo> \
+  --pull-request-status OPEN
+
+# For each open PR, re-trigger a full review by clearing the
+# Postgres state row (forces "no prior review" -> full diff path).
+psql "$DATABASE_URL" <<SQL
+DELETE FROM review_state
+ WHERE repository_arn = 'arn:aws:codecommit:<region>:<account>:<repo>'
+   AND pr_id = '<pr-id>';
+SQL
+
+# Then post the @review-agent review command on the PR, or call the
+# CLI directly (issue #75 — the --platform codecommit flag):
+review-agent review --pr <pr-id> --platform codecommit --repo <repo>
+```
+
+Each re-review costs the full LLM spend for that PR. There is no
+incremental shortcut — that's the price of the Postgres-canonical
+posture. Document the cost overhead in your post-incident report so
+the operator can decide whether tighter RPO is worth the backup
+infrastructure cost next time.
+
+**Caveat on fingerprint dedup**: the runner's dedup middleware
+(`packages/runner/src/middleware/dedup.ts`) suppresses comments whose
+fingerprint matches one already posted on the PR. After a state-loss
+re-review, the dedup pass will hit *existing* CodeCommit comments
+(`vcs.getExistingComments`) and skip re-posting findings that were
+already there. The cost spend is still incurred for the LLM call — the
+saving is only on visible duplicate comments.
+
+### Step 5 — Resume normal operation
+
+Restart the worker pool, monitor the cost-ledger for the expected
+spike from the manual re-reviews, and close out the incident.
+
+```bash
+# Sanity check: review_state rows should now reflect the manual
+# re-reviews.
+psql "$DATABASE_URL" -c "
+  SELECT COUNT(*) AS reviewed
+    FROM review_state
+   WHERE installation_id = <id>;
+"
+```
+
+---
+
+## 4. Operational checklist
+
+Pre-incident (do this before you need it):
+
+- [ ] Postgres backups configured with RPO ≤ your tier's target.
+- [ ] PITR retention long enough to cover the alert→restore lag of
+      your on-call rotation.
+- [ ] Cross-region replica or off-site snapshot copy if your
+      regulatory regime requires geographic separation.
+- [ ] `review-agent recover audit-verify` runs as a periodic cron
+      against the live DB so chain breaks are detected within 24 h.
+- [ ] This runbook is on the on-call shared drive (not only in the
+      repo), so the on-call engineer can read it without a working
+      worker.
+
+Post-incident:
+
+- [ ] Document RPO actually achieved vs. target.
+- [ ] Record total spend on the manual re-review pass against the
+      affected installation(s).
+- [ ] If chain was broken, note the break window in the operations
+      log.
+- [ ] If SOC2 / ISO evidence retention is in scope, file the
+      restore + verify artifacts (CloudTrail entries, `audit-verify`
+      output, the snapshot identifier) with your evidence custodian.
+
+---
+
+## 5. See also
+
+- [`/SECURITY.md`](../../SECURITY.md) §8.6.6 — `recover sync-state`
+  procedure for GitHub (does **not** apply to CodeCommit).
+- [`docs/deployment/aws.md`](../deployment/aws.md) — CodeCommit
+  deployment notes; links here for the DR story.
+- [`docs/operations/retention.md`](./retention.md) — retention
+  policy + export CLI (`audit_log` / `cost_ledger`).
+- Spec §5.2.1 — CodeCommit out-of-scope items (cloneRepo,
+  getStateComment / upsertStateComment).
+- Spec §12.1.1 — Postgres-canonical state contract for CodeCommit.
+- Spec §22.1 — consolidated CodeCommit posture.
+- [`packages/platform-codecommit/README.md`](../../packages/platform-codecommit/README.md) §
+  "Disaster recovery" — adapter-side summary.

--- a/docs/specs/prd.md
+++ b/docs/specs/prd.md
@@ -57,6 +57,12 @@
 - **GitLab / Bitbucket アダプタは v1.x では対応しない**。Post-v1.0 で着手
 - **IDE 統合は v1.x では対応しない**。Web / PR コメント面のみ
 
+> CodeCommit に関する出スコープ項目（`cloneRepo` の不対応、multi-bot
+> coordination が GitHub-actor ベースで動作する点、GHES 互換性は
+> GitHub 側のみ）は、`docs/specs/review-agent-spec.md` §5.2.1 と
+> §22.1 に統合的に整理してある。本 PRD はその要約のみ示し、詳細は
+> spec を参照する。
+
 ---
 
 ## 3. 課題の定義

--- a/docs/specs/prd.md
+++ b/docs/specs/prd.md
@@ -62,6 +62,11 @@
 > GitHub 側のみ）は、`docs/specs/review-agent-spec.md` §5.2.1 と
 > §22.1 に統合的に整理してある。本 PRD はその要約のみ示し、詳細は
 > spec を参照する。
+>
+> VCS 抽象化（`VcsCapabilities` + Reader/Writer/StateStore のロール
+> 分割 + platform registry）の契約は `docs/specs/review-agent-spec.md`
+> §5.2 と §22.x、および `packages/core/README.md` の "VCS abstraction"
+> 節に集約してある。新規アダプタ追加時はそちらを参照すること。
 
 ---
 

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -877,8 +877,12 @@ export const verifyGithubSignature = (secret: string) =>
   });
 ```
 
-CodeCommit (via SNS): use AWS SNS message signature verification with SigV4. Use
-`@aws-sdk/credential-providers` for the worker's IAM role.
+CodeCommit (via SNS): use AWS SNS message signature verification with the
+RSA-SHA1/SHA256 signing-cert scheme (the asymmetric signature SNS attaches to
+each message — distinct from SigV4, which is the AWS request-signing scheme used
+for SDK calls; see
+https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html).
+Use `@aws-sdk/credential-providers` for the worker's IAM role.
 
 ### 7.2 Idempotency
 
@@ -1232,6 +1236,7 @@ const octokit = new Octokit({ auth: token });
   codecommit:GetPullRequest
   codecommit:GetDifferences
   codecommit:GetFile
+  codecommit:GetCommentsForPullRequest
   codecommit:PostCommentForPullRequest
   codecommit:PostCommentReply
   codecommit:UpdatePullRequestApprovalState  # only if approval is configured

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -38,6 +38,10 @@ Build a self-hostable, OSS, AI code review agent that:
   Anthropic API key (BYOK) and runs on their own infra.
 - **No GitLab/Bitbucket adapter in v1.x.** Only GitHub and CodeCommit. Other VCS
   platforms come post-v1.0.
+  - **GHES note.** GitHub Enterprise Server compatibility (issue #49,
+    `docs/deployment/ghes.md`) is GitHub-side only. AWS CodeCommit is a
+    managed AWS service with no on-premises / self-hosted equivalent, so
+    there is no "CodeCommit Enterprise Server" tier to support.
 - **No code modification.** The agent does not commit, push, edit files in the user's
   repo, or open PRs. Read-only on source, write-only on PR comments.
 - **No model fine-tuning.** No training data collection. Inference only.
@@ -718,6 +722,36 @@ source of truth** for review state, keyed by `(repository_arn, pr_id)`. The
 adapter interface remains the same; the GitHub adapter writes both, the
 CodeCommit adapter writes only to Postgres. This divergence is documented in
 `packages/platform-codecommit/README.md` and the user-facing docs.
+
+#### 5.2.1 CodeCommit out of scope (deliberate)
+
+The CodeCommit adapter implements the full `VCS` interface but several
+methods are intentionally inert because the underlying platform either
+lacks the API or the runner does not need it. These are **permanent
+design decisions**, not unfinished work:
+
+- **`cloneRepo` is unsupported.** The CodeCommit adapter's `cloneRepo`
+  throws `not supported` (`packages/platform-codecommit/src/adapter.ts`).
+  The runner's review flow uses `getDiff()` + `getFile()` exclusively —
+  it never requires a working tree clone. CodeCommit auth would also
+  require `git-remote-codecommit` or AWS-signed HTTPS, which we
+  deliberately do not bundle. If a future feature needs a clone, it
+  must declare so via `VcsCapabilities.clone` (issue #80) and either
+  fall back to the API path or refuse to run on CodeCommit.
+- **`getStateComment` / `upsertStateComment` are no-ops** (return
+  `null` / resolve without side effect). See §12.1.1 — Postgres is
+  canonical for CodeCommit, and the adapter's no-op is defense in
+  depth so accidental callers cannot corrupt state by writing to a
+  comment that will not survive HTML escaping.
+- **`review.event` (APPROVE / REQUEST_CHANGES) is currently dropped**
+  by `postReview`. Issue #74 wires this to
+  `UpdatePullRequestApprovalState` behind an opt-in
+  `codecommit.approvalState` config flag.
+- **Commit-message access for the LLM context** (§7.6,
+  `ReviewInput.commits[]` per issue #66) is **GitHub-only**. The
+  CodeCommit `GetDifferences` API does not return commit metadata in
+  the diff response and we do not call `GetCommitsFromMergeBase` per
+  review for cost reasons.
 
 ---
 
@@ -2595,6 +2629,43 @@ v1.0+ as design work, not implementation blockers. Status as of v0.3 release:
     **Resolved**: v0.3 ships with `manifest.json` + SHA-256 only (mandatory).
     Cosign attestation is **deferred to v1.1** — re-evaluate based on
     contributor demand. Track in a roadmap issue, not in the spec.
+
+### 22.1 CodeCommit-specific posture (consolidated)
+
+These items consolidate CodeCommit design constraints that were
+previously scattered in code comments and adapter READMEs. None of
+them are open questions — they are documented here so contributors do
+not mistake them for gaps in implementation.
+
+1. **Multi-bot coordination on CodeCommit.** Issue #48
+   (`docs/configuration/coordination.md`) ships the multi-bot
+   coordination policy with `coordination.other_bots: ignore` /
+   `defer_if_present`. **The detection list
+   (`packages/config/src/known-bots.ts`) is GitHub-actor-based** —
+   detection scans `existingComments[].author.login` for GitHub bot
+   logins (`coderabbitai[bot]`, etc.). CodeCommit comments come from
+   IAM principals rather than `*[bot]` user logins; the GitHub
+   actor-string detector therefore matches nothing on CodeCommit, and
+   `defer_if_present` reduces to `ignore` in practice. Operators who
+   need multi-bot coordination on CodeCommit should rely on AWS
+   approval-rule templates or external orchestration. This is **not**
+   a planned feature — the demand vs. complexity is unfavourable
+   (CodeCommit is in maintenance mode upstream;
+   `packages/platform-codecommit/README.md` §1 already warns about
+   that).
+2. **GHES compatibility (#49) is GitHub-only.** AWS CodeCommit is a
+   managed AWS service with no on-premises tier; there is no
+   "CodeCommit Enterprise Server". See §1.2 for the corresponding
+   non-goal entry.
+3. **Disaster-recovery posture differs from GitHub.** Postgres is
+   canonical for review state on CodeCommit (§12.1.1). The
+   `recover sync-state` CLI command is GitHub-only — there is no
+   `recover sync-state-from-codecommit` because the hidden-state
+   markers do not survive CodeCommit's HTML escaping. See
+   `docs/operations/codecommit-disaster-recovery.md` for the
+   operator-facing runbook.
+4. **`cloneRepo` is intentionally unsupported** on CodeCommit
+   (§5.2.1). The runner uses `getDiff()` + `getFile()`.
 
 ---
 

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -662,17 +662,42 @@ export interface ReviewOutput {
 }
 
 // packages/core/src/vcs.ts
-export interface VCS {
+//
+// The VCS contract is decomposed into a static capability matrix
+// (`VcsCapabilities`) and three role interfaces (Reader / Writer /
+// StateStore). Callers should depend on the narrowest role they need.
+// See `packages/core/README.md` for the per-adapter capability table
+// and registry-based dispatch pattern.
+
+export type VcsCapabilities = {
+  readonly clone: boolean;                                  // false on CodeCommit
+  readonly stateComment: 'native' | 'postgres-only';        // 'postgres-only' on CodeCommit
+  readonly approvalEvent: 'github' | 'codecommit' | 'none'; // mapping target for review.event
+  readonly commitMessages: boolean;                         // false on CodeCommit
+};
+
+export type VcsReader = {
   getPR(ref: PRRef): Promise<PR>;
-  getDiff(ref: PRRef, opts: { sinceSha?: string }): Promise<Diff>;
+  getDiff(ref: PRRef, opts?: { sinceSha?: string }): Promise<Diff>;
   getFile(ref: PRRef, path: string, sha: string): Promise<Buffer>;
   cloneRepo(ref: PRRef, dir: string, opts: CloneOpts): Promise<void>;
+  getExistingComments(ref: PRRef): Promise<ReadonlyArray<ExistingComment>>;
+};
+
+export type VcsWriter = {
   postReview(ref: PRRef, review: ReviewPayload): Promise<void>;
   postSummary(ref: PRRef, body: string): Promise<{ commentId: string }>;
-  getExistingComments(ref: PRRef): Promise<ExistingComment[]>;
+};
+
+export type VcsStateStore = {
   getStateComment(ref: PRRef): Promise<ReviewState | null>;
   upsertStateComment(ref: PRRef, state: ReviewState): Promise<void>;
-}
+};
+
+export type VCS = {
+  readonly platform: 'github' | 'codecommit';
+  readonly capabilities: VcsCapabilities;
+} & VcsReader & VcsWriter & VcsStateStore;
 
 export interface CloneOpts {
   depth?: number;            // default 50
@@ -2630,6 +2655,50 @@ v1.0+ as design work, not implementation blockers. Status as of v0.3 release:
     **Resolved**: v0.3 ships with `manifest.json` + SHA-256 only (mandatory).
     Cosign attestation is **deferred to v1.1** — re-evaluate based on
     contributor demand. Track in a roadmap issue, not in the spec.
+
+### 22.x Platform registry contract (VCS dispatch)
+
+Adapter packages (`@review-agent/platform-github`,
+`@review-agent/platform-codecommit`) export a `PlatformDefinition`
+and call `registerPlatform(definition)` from `@review-agent/core` at
+module load. Application composition roots (`action`, `server`,
+`cli`) import the adapter package once for its registration side
+effect; subsequent code looks up the adapter via
+`getPlatform(prRef.platform).create(config)` rather than a hard-coded
+chain of `if (platform === 'github') ...`.
+
+**Why a registry instead of a literal union switch:** future adapters
+add value at the dispatch layer (server/runner) only; the persisted
+JobMessage / Postgres rows continue to carry the literal-union
+`platform` discriminator. Decoupling dispatch from the union means a
+new adapter package can ship in `packages/platform-foo/` without
+touching the core type or running a DB migration to widen
+`PRRef.platform`. The registry never serializes — it is constructed
+fresh on each worker start.
+
+**Intentional non-extension to `string` PlatformId.** The branded
+`PlatformId` (`string & { __brand: 'PlatformId' }`) is purely a
+compile-time helper; at runtime it is a normal string. `PRRef.platform`
+keeps its `'github' | 'codecommit'` literal-union shape because
+existing serialized JobMessage / `review_state` rows would otherwise
+fail to parse. Widening `PRRef.platform` to `string` is **v2 work**:
+it requires a JobMessage schema version bump (currently `v1` in
+`packages/core/src/queue.ts`) and a Postgres migration on every table
+that joins on the discriminator. v1.x adapters live inside the
+existing union; the registry is a dispatch helper, not a type-erasure
+layer.
+
+**Adapter responsibilities at registration:**
+
+- Export the `PlatformDefinition` (id, `parseRef`, `create(config)`).
+- Validate the `config: unknown` argument inside `create` — the
+  registry intentionally types config as opaque to avoid coupling
+  `@review-agent/core` to every adapter's config shape.
+- Throw a typed error from `create` when required config (auth token,
+  AWS client, etc.) is missing.
+
+See `packages/core/README.md` for the full per-adapter capability
+table and example usage.
 
 ### 22.1 CodeCommit-specific posture (consolidated)
 

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -1611,8 +1611,9 @@ For CodeCommit:
 - Disaster recovery: if Postgres is destroyed, all CodeCommit reviews
   fall back to "full review" on the next webhook. There is no `recover
   sync-state-from-codecommit` equivalent (cannot reconstruct from comments).
-  Document this limitation in `docs/deployment/aws.md` under the CodeCommit
-  section.
+  The operator-facing recovery procedure lives at
+  [`docs/operations/codecommit-disaster-recovery.md`](../operations/codecommit-disaster-recovery.md);
+  `docs/deployment/aws.md` cross-links it.
 - Backups: RDS automated snapshots (35-day retention) cover state recovery
   for CodeCommit installations.
 

--- a/packages/action/src/run.test.ts
+++ b/packages/action/src/run.test.ts
@@ -39,6 +39,12 @@ const samplePR: PR = {
 function makeVCS(overrides: Partial<VCS> = {}): VCS {
   return {
     platform: 'github',
+    capabilities: {
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    },
     getPR: vi.fn(async () => samplePR),
     getDiff: vi.fn(async () => ({ baseSha: 'B', headSha: 'H', files: [] })),
     getFile: vi.fn(),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "@review-agent/core": "workspace:*",
     "@review-agent/db": "workspace:*",
     "@review-agent/llm": "workspace:*",
+    "@review-agent/platform-codecommit": "workspace:*",
     "@review-agent/platform-github": "workspace:*",
     "@review-agent/runner": "workspace:*",
     "commander": "12.1.0",

--- a/packages/cli/src/commands/recover.test.ts
+++ b/packages/cli/src/commands/recover.test.ts
@@ -145,6 +145,19 @@ describe('recoverSyncStateCommand', () => {
     expect(upsertState).not.toHaveBeenCalled();
   });
 
+  it('short-circuits on --platform codecommit with informative stderr', async () => {
+    const io = recordingIo();
+    const result = await recoverSyncStateCommand(io, {
+      repo: 'demo',
+      installationId: 1n,
+      env: {} as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+    });
+    expect(result).toEqual({ status: 'ok', recovered: 0, missing: [] });
+    expect(io.err.join('')).toContain('recover sync-state is GitHub-only');
+    expect(io.err.join('')).toContain('codecommit-disaster-recovery');
+  });
+
   it('handles an empty repo (no open PRs)', async () => {
     const io = recordingIo();
     const upsertState = vi.fn(async () => undefined);

--- a/packages/cli/src/commands/recover.test.ts
+++ b/packages/cli/src/commands/recover.test.ts
@@ -35,6 +35,12 @@ function fakeState(overrides: Partial<ReviewState> = {}): ReviewState {
 function fakeVcs(stateByPr: Record<number, ReviewState | null>): VCS {
   return {
     platform: 'github',
+    capabilities: {
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    },
     getPR: async () => {
       throw new Error('unused');
     },

--- a/packages/cli/src/commands/recover.ts
+++ b/packages/cli/src/commands/recover.ts
@@ -3,10 +3,13 @@ import type { PRRef, ReviewState, VCS } from '@review-agent/core';
 import { createGithubVCS } from '@review-agent/platform-github';
 import type { ProgramIo } from '../io.js';
 
+export type RecoverPlatform = 'github' | 'codecommit';
+
 export type RecoverSyncStateOpts = {
   readonly repo: string;
   readonly installationId: bigint;
   readonly env: NodeJS.ProcessEnv;
+  readonly platform?: RecoverPlatform;
   /** Test seam for the underlying VCS adapter. */
   readonly createVCS?: (token: string) => VCS;
   /** Test seam for the PR-list call. */
@@ -40,6 +43,13 @@ export async function recoverSyncStateCommand(
   io: ProgramIo,
   opts: RecoverSyncStateOpts,
 ): Promise<RecoverSyncStateResult> {
+  const platform: RecoverPlatform = opts.platform ?? 'github';
+  if (platform === 'codecommit') {
+    io.stderr(
+      'recover sync-state is GitHub-only (CodeCommit uses Postgres-canonical state; see docs/operations/codecommit-disaster-recovery.md).\n',
+    );
+    return { status: 'ok', recovered: 0, missing: [] };
+  }
   const token = opts.env.REVIEW_AGENT_GH_TOKEN ?? opts.env.GITHUB_TOKEN;
   if (!token) {
     io.stderr('REVIEW_AGENT_GH_TOKEN (or GITHUB_TOKEN) is required.\n');

--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -269,6 +269,64 @@ describe('runReviewCommand', () => {
     expect(result.status).toBe('reviewed');
   });
 
+  it('runs codecommit happy path without a GH token', async () => {
+    const io = recordingIo();
+    const ccVcs: VCS = {
+      ...fakeVcs(),
+      platform: 'codecommit',
+      capabilities: {
+        clone: false,
+        stateComment: 'postgres-only',
+        approvalEvent: 'codecommit',
+        commitMessages: false,
+      },
+      getPR: async () =>
+        fakePR({ ref: { platform: 'codecommit', owner: '', repo: 'demo', number: 42 } }),
+    };
+    const result = await runReviewCommand(io, {
+      repo: 'demo',
+      pr: 42,
+      configPath: 'missing.yml',
+      post: false,
+      platform: 'codecommit',
+      env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
+      readFile: async () => {
+        throw new Error('not found');
+      },
+      createVCS: () => ccVcs,
+      createProvider: () => fakeProvider({ summary: 'ok' }),
+    });
+    expect(result.status).toBe('reviewed');
+  });
+
+  it('reports auth_failed when --platform codecommit is used without --repo', async () => {
+    const io = recordingIo();
+    const result = await runReviewCommand(io, {
+      repo: '',
+      pr: 42,
+      configPath: 'missing.yml',
+      post: false,
+      platform: 'codecommit',
+      env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
+    });
+    expect(result.status).toBe('auth_failed');
+    expect(io.err.join('')).toContain('Missing required --repo for --platform codecommit');
+  });
+
+  it('rejects malformed codecommit --repo (contains slash)', async () => {
+    const io = recordingIo();
+    await expect(() =>
+      runReviewCommand(io, {
+        repo: 'owner/repo',
+        pr: 1,
+        configPath: 'missing.yml',
+        post: false,
+        platform: 'codecommit',
+        env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toThrow(/codecommit/);
+  });
+
   it('skips when author is in ignore_authors', async () => {
     const io = recordingIo();
     const yaml = 'reviews:\n  ignore_authors: ["alice"]\n';

--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -41,6 +41,12 @@ function fakePR(overrides: Partial<PR> = {}): PR {
 function fakeVcs(overrides: Partial<VCS> = {}): VCS {
   const base: VCS = {
     platform: 'github',
+    capabilities: {
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    },
     getPR: async () => fakePR(),
     getDiff: async () => ({ baseSha: 'b1', headSha: 'h1', files: [] }),
     getFile: async () => Buffer.from(''),

--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -1,3 +1,4 @@
+import type { Config } from '@review-agent/config';
 import type { PR, ReviewState, VCS } from '@review-agent/core';
 import type { LlmProvider, ReviewOutput } from '@review-agent/llm';
 import { describe, expect, it, vi } from 'vitest';
@@ -325,6 +326,77 @@ describe('runReviewCommand', () => {
         env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
       }),
     ).rejects.toThrow(/codecommit/);
+  });
+
+  it('threads codecommit.approvalState=managed from config into the VCS factory (#74 follow-on)', async () => {
+    const io = recordingIo();
+    const ccVcs: VCS = {
+      ...fakeVcs(),
+      platform: 'codecommit',
+      capabilities: {
+        clone: false,
+        stateComment: 'postgres-only',
+        approvalEvent: 'codecommit',
+        commitMessages: false,
+      },
+      getPR: async () =>
+        fakePR({ ref: { platform: 'codecommit', owner: '', repo: 'demo', number: 42 } }),
+    };
+    const yaml = 'codecommit:\n  approvalState: managed\n';
+    let captured: Config | null = null;
+    const result = await runReviewCommand(io, {
+      repo: 'demo',
+      pr: 42,
+      configPath: '.review-agent.yml',
+      post: false,
+      platform: 'codecommit',
+      env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
+      readFile: async () => yaml,
+      createVCS: (_token, config) => {
+        captured = config;
+        return ccVcs;
+      },
+      createProvider: () => fakeProvider({ summary: 'ok' }),
+    });
+    expect(result.status).toBe('reviewed');
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Config).codecommit.approvalState).toBe('managed');
+  });
+
+  it('defaults codecommit.approvalState to off when config is missing (#74 follow-on)', async () => {
+    const io = recordingIo();
+    const ccVcs: VCS = {
+      ...fakeVcs(),
+      platform: 'codecommit',
+      capabilities: {
+        clone: false,
+        stateComment: 'postgres-only',
+        approvalEvent: 'codecommit',
+        commitMessages: false,
+      },
+      getPR: async () =>
+        fakePR({ ref: { platform: 'codecommit', owner: '', repo: 'demo', number: 42 } }),
+    };
+    let captured: Config | null = null;
+    const result = await runReviewCommand(io, {
+      repo: 'demo',
+      pr: 42,
+      configPath: 'missing.yml',
+      post: false,
+      platform: 'codecommit',
+      env: { ANTHROPIC_API_KEY: 'k' } as NodeJS.ProcessEnv,
+      readFile: async () => {
+        throw new Error('not found');
+      },
+      createVCS: (_token, config) => {
+        captured = config;
+        return ccVcs;
+      },
+      createProvider: () => fakeProvider({ summary: 'ok' }),
+    });
+    expect(result.status).toBe('reviewed');
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Config).codecommit.approvalState).toBe('off');
   });
 
   it('skips when author is in ignore_authors', async () => {

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -26,7 +26,7 @@ export type RunReviewOpts = {
   readonly costCapUsd?: number;
   readonly env: NodeJS.ProcessEnv;
   readonly readFile?: (p: string, enc: 'utf8') => Promise<string>;
-  readonly createVCS?: (token: string | null) => VCS;
+  readonly createVCS?: (token: string | null, config: Config) => VCS;
   readonly createProvider?: (apiKey: string, config: Config) => LlmProvider;
   readonly confirm?: () => Promise<boolean>;
 };
@@ -66,7 +66,7 @@ export async function runReviewCommand(
   const readFile = opts.readFile ?? defaultReadFile;
   const config = applyOverrides(await loadConfig(opts.configPath, readFile), opts);
 
-  const vcs = (opts.createVCS ?? ((t) => defaultCreateVCS(platform, t)))(token);
+  const vcs = (opts.createVCS ?? ((t, c) => defaultCreateVCS(platform, t, c)))(token, config);
   const pr = await vcs.getPR(ref);
 
   const skipReason = decideSkip(pr, config);
@@ -166,9 +166,9 @@ function parseRef(platform: ReviewPlatform, repo: string, prNumber: number): PRR
   };
 }
 
-function defaultCreateVCS(platform: ReviewPlatform, token: string | null): VCS {
+function defaultCreateVCS(platform: ReviewPlatform, token: string | null, config: Config): VCS {
   if (platform === 'codecommit') {
-    return createCodecommitVCS();
+    return createCodecommitVCS({ approvalState: config.codecommit.approvalState });
   }
   if (!token) {
     throw new Error('GitHub token is required for --platform github.');

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -2,6 +2,7 @@ import { readFile as fsReadFile } from 'node:fs/promises';
 import { type Config, defaultConfig, loadConfigFromYaml, mergeWithEnv } from '@review-agent/config';
 import type { PR, PRRef, ReviewState, VCS } from '@review-agent/core';
 import { createAnthropicProvider, type LlmProvider } from '@review-agent/llm';
+import { createCodecommitVCS } from '@review-agent/platform-codecommit';
 import { createGithubVCS } from '@review-agent/platform-github';
 import {
   buildReviewState,
@@ -12,17 +13,20 @@ import {
 } from '@review-agent/runner';
 import type { ProgramIo } from '../io.js';
 
+export type ReviewPlatform = 'github' | 'codecommit';
+
 export type RunReviewOpts = {
   readonly repo: string;
   readonly pr: number;
   readonly configPath: string;
   readonly post: boolean;
+  readonly platform?: ReviewPlatform;
   readonly language?: string;
   readonly profile?: string;
   readonly costCapUsd?: number;
   readonly env: NodeJS.ProcessEnv;
   readonly readFile?: (p: string, enc: 'utf8') => Promise<string>;
-  readonly createVCS?: (token: string) => VCS;
+  readonly createVCS?: (token: string | null) => VCS;
   readonly createProvider?: (apiKey: string, config: Config) => LlmProvider;
   readonly confirm?: () => Promise<boolean>;
 };
@@ -38,9 +42,18 @@ export async function runReviewCommand(
   io: ProgramIo,
   opts: RunReviewOpts,
 ): Promise<RunReviewResult> {
-  const token = opts.env.REVIEW_AGENT_GH_TOKEN ?? opts.env.GITHUB_TOKEN;
-  if (!token) {
-    io.stderr('REVIEW_AGENT_GH_TOKEN (or GITHUB_TOKEN) is required.\n');
+  const platform: ReviewPlatform = opts.platform ?? 'github';
+
+  let token: string | null = null;
+  if (platform === 'github') {
+    const t = opts.env.REVIEW_AGENT_GH_TOKEN ?? opts.env.GITHUB_TOKEN;
+    if (!t) {
+      io.stderr('REVIEW_AGENT_GH_TOKEN (or GITHUB_TOKEN) is required.\n');
+      return { status: 'auth_failed', postedComments: 0, costUsd: 0 };
+    }
+    token = t;
+  } else if (!opts.repo) {
+    io.stderr('Missing required --repo for --platform codecommit\n');
     return { status: 'auth_failed', postedComments: 0, costUsd: 0 };
   }
   const apiKey = opts.env.ANTHROPIC_API_KEY;
@@ -49,11 +62,11 @@ export async function runReviewCommand(
     return { status: 'auth_failed', postedComments: 0, costUsd: 0 };
   }
 
-  const ref = parseRepo(opts.repo, opts.pr);
+  const ref = parseRef(platform, opts.repo, opts.pr);
   const readFile = opts.readFile ?? defaultReadFile;
   const config = applyOverrides(await loadConfig(opts.configPath, readFile), opts);
 
-  const vcs = (opts.createVCS ?? ((t) => createGithubVCS({ token: t })))(token);
+  const vcs = (opts.createVCS ?? ((t) => defaultCreateVCS(platform, t)))(token);
   const pr = await vcs.getPR(ref);
 
   const skipReason = decideSkip(pr, config);
@@ -132,7 +145,15 @@ export async function runReviewCommand(
   };
 }
 
-function parseRepo(repo: string, prNumber: number): PRRef {
+function parseRef(platform: ReviewPlatform, repo: string, prNumber: number): PRRef {
+  if (platform === 'codecommit') {
+    if (!repo || /[\s/]/.test(repo)) {
+      throw new Error(
+        `--repo for --platform codecommit must be a repository name (got '${repo}').`,
+      );
+    }
+    return { platform: 'codecommit', owner: '', repo, number: prNumber };
+  }
   const match = /^([^/\s]+)\/([^/\s]+)$/.exec(repo);
   if (!match) {
     throw new Error(`--repo must be in 'owner/repo' format (got '${repo}').`);
@@ -143,6 +164,16 @@ function parseRepo(repo: string, prNumber: number): PRRef {
     repo: match[2] ?? '',
     number: prNumber,
   };
+}
+
+function defaultCreateVCS(platform: ReviewPlatform, token: string | null): VCS {
+  if (platform === 'codecommit') {
+    return createCodecommitVCS();
+  }
+  if (!token) {
+    throw new Error('GitHub token is required for --platform github.');
+  }
+  return createGithubVCS({ token });
 }
 
 async function loadConfig(

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -16,6 +16,7 @@ export type ProgramDeps = {
 };
 
 const PROFILES = ['chill', 'assertive'] as const;
+const PLATFORMS = ['github', 'codecommit'] as const;
 
 export function buildProgram(deps: ProgramDeps = {}): Command {
   const io = deps.io ?? defaultIo();
@@ -30,8 +31,13 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
   program
     .command('review')
     .description('Run a review against a single PR using a PAT.')
-    .requiredOption('--repo <owner/repo>', 'repository in `owner/name` format')
+    .requiredOption('--repo <repo>', "repository: 'owner/name' for github, '<name>' for codecommit")
     .requiredOption('--pr <n>', 'PR number', (v) => Number.parseInt(v, 10))
+    .addOption(
+      new Option('--platform <platform>', 'VCS platform (default: github)')
+        .choices([...PLATFORMS])
+        .default('github'),
+    )
     .option('--config <path>', 'path to .review-agent.yml', '.review-agent.yml')
     .option('--lang <code>', 'override output language (BCP 47)')
     .addOption(new Option('--profile <profile>', 'override review profile').choices([...PROFILES]))
@@ -43,6 +49,7 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
         pr: opts.pr,
         configPath: opts.config,
         post: !!opts.post,
+        platform: opts.platform,
         ...(opts.lang ? { language: opts.lang } : {}),
         ...(opts.profile ? { profile: opts.profile } : {}),
         ...(opts.costCapUsd !== undefined ? { costCapUsd: opts.costCapUsd } : {}),
@@ -152,10 +159,16 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
     )
     .requiredOption('--repo <owner/repo>', 'repository in `owner/name` format')
     .requiredOption('--installation <id>', 'GitHub App installation ID', (v) => BigInt(v))
+    .addOption(
+      new Option('--platform <platform>', 'VCS platform (default: github)')
+        .choices([...PLATFORMS])
+        .default('github'),
+    )
     .action(async (opts: RecoverSyncStateCliOpts) => {
       const result = await recoverSyncStateCommand(io, {
         repo: opts.repo,
         installationId: opts.installation,
+        platform: opts.platform,
         env,
       });
       io.exit(result.status === 'auth_failed' ? 1 : 0);
@@ -169,6 +182,7 @@ type ReviewCliOpts = {
   repo: string;
   pr: number;
   config: string;
+  platform: (typeof PLATFORMS)[number];
   lang?: string;
   profile?: (typeof PROFILES)[number];
   costCapUsd?: number;
@@ -182,6 +196,7 @@ type EvalCliOpts = {
 type RecoverSyncStateCliOpts = {
   repo: string;
   installation: bigint;
+  platform: (typeof PLATFORMS)[number];
 };
 
 type SetupWorkspaceCliOpts = {

--- a/packages/config/src/loader.test.ts
+++ b/packages/config/src/loader.test.ts
@@ -177,6 +177,22 @@ describe('loadConfigFromYaml — explicit values', () => {
       ConfigError,
     );
   });
+
+  it("defaults codecommit.approvalState to 'off' (v0.2 back-compat)", () => {
+    const cfg = loadConfigFromYaml('');
+    expect(cfg.codecommit.approvalState).toBe('off');
+  });
+
+  it("parses codecommit.approvalState: 'managed'", () => {
+    const cfg = loadConfigFromYaml('codecommit:\n  approvalState: managed\n');
+    expect(cfg.codecommit.approvalState).toBe('managed');
+  });
+
+  it('rejects an unknown codecommit.approvalState value', () => {
+    expect(() => loadConfigFromYaml('codecommit:\n  approvalState: blocking\n')).toThrow(
+      ConfigError,
+    );
+  });
 });
 
 describe('defaultConfig', () => {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -127,6 +127,26 @@ const IncrementalSchema = z
   })
   .strict();
 
+// CodeCommit-specific operator options (issue #74). At the moment the
+// only field is `approvalState`, which controls whether the CodeCommit
+// adapter maps `review.event` to `UpdatePullRequestApprovalState`.
+//
+//   off (default)  — preserve v0.2 behavior. The adapter ignores
+//                    `review.event`; merge-blocking is left to the
+//                    operator's approval rules in CodeCommit itself.
+//   managed        — translate `APPROVE` → `UpdatePullRequestApprovalState(APPROVE)`
+//                    and `REQUEST_CHANGES` → `UpdatePullRequestApprovalState(REVOKE)`.
+//                    `COMMENT` is a no-op. Requires the agent's IAM
+//                    principal to be a target of an approval rule on
+//                    the PR; otherwise the call is a logged no-op.
+//
+// Other VCS adapters (GitHub, Bitbucket, ...) ignore this section.
+const CodecommitSchema = z
+  .object({
+    approvalState: z.enum(['managed', 'off']).default('off'),
+  })
+  .strict();
+
 // Server-mode workspace provisioning. Only consulted by
 // `@review-agent/server`'s `provisionWorkspace` — Action mode ignores
 // this section (the GitHub Actions runner does `actions/checkout`
@@ -193,6 +213,7 @@ export const ConfigSchema = z
     incremental: IncrementalSchema.default({}),
     coordination: CoordinationSchema.default({}),
     server: ServerSchema.default({}),
+    codecommit: CodecommitSchema.default({}),
   })
   .strict();
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,15 +7,98 @@ no clock reads.
 This package is the foundation: every other package (`platform-*`, `llm`,
 `runner`, `action`, `server`, `cli`, `config`) depends on it.
 
+## VCS abstraction
+
+The `VCS` interface is the contract every platform adapter
+(`platform-github`, `platform-codecommit`) implements. It has four
+parts:
+
+| Part                                | What it covers                                                    |
+|-------------------------------------|-------------------------------------------------------------------|
+| `platform` literal                  | `'github' \| 'codecommit'` — persisted in JobMessage / DB rows.   |
+| `capabilities: VcsCapabilities`     | Static "what does this platform support" matrix (see below).     |
+| `VcsReader`                         | `getPR` / `getDiff` / `getFile` / `cloneRepo` / `getExistingComments`. |
+| `VcsWriter`                         | `postReview` / `postSummary`.                                     |
+| `VcsStateStore`                     | `getStateComment` / `upsertStateComment`.                         |
+
+`VCS = { platform; capabilities } & VcsReader & VcsWriter & VcsStateStore`.
+Callers that only need a subset (e.g. the `recover sync-state` flow
+uses just `VcsStateStore`) can depend on the narrower role.
+
+### Capabilities matrix (shipped adapters)
+
+| Capability                  | `platform-github` | `platform-codecommit` | Notes |
+|-----------------------------|-------------------|------------------------|-------|
+| `clone`                     | `true`            | `false`               | CodeCommit `cloneRepo` throws by design (spec §5.2.1); the runner uses `getDiff()`+`getFile()`. |
+| `stateComment`              | `'native'`        | `'postgres-only'`     | GitHub embeds the canonical state in a hidden comment; CodeCommit's HTML escaping mangles the marker (spec §12.1.1). |
+| `approvalEvent`             | `'github'`        | `'codecommit'`        | GitHub uses `pulls.createReview({event})`; CodeCommit's mapping target is `UpdatePullRequestApprovalState` (opt-in via `codecommit.approvalState`; #74). |
+| `commitMessages`            | `true`            | `false`               | CodeCommit has no per-PR commit-listing API. |
+
+The runner should branch on these flags **before** calling the
+underlying method — e.g. the workspace provisioner refuses
+`strategy: 'sparse-clone'` when `capabilities.clone === false` with a
+typed operator-facing error, instead of letting the adapter throw a
+lower-level "CodeCommit clone is not supported" message.
+
+### Platform registry
+
+Adapters register themselves at module load via
+`registerPlatform(definition)`. The composition root (`action`,
+`server`, `cli`) imports the adapter package once, which triggers
+registration as a side effect; subsequent code looks up the adapter
+through `getPlatform(prRef.platform).create(config)`.
+
+```ts
+import { getPlatform } from '@review-agent/core';
+import '@review-agent/platform-github';     // registers under 'github'
+import '@review-agent/platform-codecommit'; // registers under 'codecommit'
+
+const def = getPlatform(jobMessage.prRef.platform);
+const vcs = def.create({ token: '...' }); // adapter-specific config
+```
+
+**Intentional limitation:** `PRRef.platform` keeps its
+`'github' | 'codecommit'` literal-union shape so JobMessage rows
+already persisted to SQS / Postgres parse without a schema bump.
+Widening `PRRef.platform` to plain `string` is v2 work (DB migration
++ JobMessage schema version). The registry is a dispatch helper, not
+a type-erasure layer. See spec §22.x.
+
+## Test helpers
+
+The package re-exports a small set of fakes for unit tests in any
+package that depends on `core`:
+
+- `createFakeVCS({ ...overrides })` — full VCS surface; defaults to
+  GitHub-like capabilities.
+- `createFakeVcsReader` / `createFakeVcsWriter` /
+  `createFakeVcsStateStore` — narrow-role fakes for tests that only
+  exercise one role.
+- `DEFAULT_FAKE_CAPABILITIES` — the GitHub-shaped capability defaults.
+
+These factories never enforce capability ↔ behavior consistency
+(a fake can advertise `clone: false` and still resolve `cloneRepo`).
+Tests asserting that runtime code respects capability flags must do
+that check themselves.
+
 ## Exports
 
-- `VCS`, `PRRef`, `PR`, `Diff`, `DiffFile`, `CloneOpts`, `ExistingComment` —
-  VCS adapter interface used by `platform-github` and `platform-codecommit`.
+- `VCS`, `PRRef`, `PR`, `Diff`, `DiffFile`, `CloneOpts`,
+  `ExistingComment`, `VcsCapabilities`, `VcsReader`, `VcsWriter`,
+  `VcsStateStore` — VCS adapter contract.
+- `PlatformDefinition`, `PlatformId`, `getPlatform`,
+  `registerPlatform`, `unregisterPlatform`, `listPlatforms`,
+  `platformId` — platform registry.
+- `createFakeVCS`, `createFakeVcsReader`, `createFakeVcsWriter`,
+  `createFakeVcsStateStore`, `DEFAULT_FAKE_CAPABILITIES` —
+  test helpers.
 - `InlineComment`, `ReviewPayload`, `ReviewState`, `CostLedgerRow`,
   `Severity`, `Side` — review domain types.
-- `InlineCommentSchema`, `ReviewOutputSchema` — Zod schemas validating LLM
-  output, including refusals of broadcast mentions and shell-command bodies.
-- `fingerprint(c)` — SHA-256 sliced to 16 hex chars (64 bits) for dedup.
+- `InlineCommentSchema`, `ReviewOutputSchema` — Zod schemas validating
+  LLM output, including refusals of broadcast mentions and
+  shell-command bodies.
+- `fingerprint(c)` — SHA-256 sliced to 16 hex chars (64 bits) for
+  dedup.
 - `ReviewAgentError` and discriminated subclasses — error taxonomy.
 
 ## License

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,16 @@ export {
   type KmsClient,
 } from './kms/index.js';
 export {
+  _resetPlatformRegistryForTests,
+  getPlatform,
+  listPlatforms,
+  type PlatformDefinition,
+  type PlatformId,
+  platformId,
+  registerPlatform,
+  unregisterPlatform,
+} from './platforms.js';
+export {
   type DequeueOpts,
   type JobMessage,
   JobMessageSchema,
@@ -95,6 +105,13 @@ export {
   type ReviewStateInput,
   ReviewStateSchema,
 } from './schemas.js';
+export {
+  createFakeVCS,
+  createFakeVcsReader,
+  createFakeVcsStateStore,
+  createFakeVcsWriter,
+  DEFAULT_FAKE_CAPABILITIES,
+} from './test-helpers.js';
 export type {
   CloneOpts,
   Diff,
@@ -104,4 +121,8 @@ export type {
   PR,
   PRRef,
   VCS,
+  VcsCapabilities,
+  VcsReader,
+  VcsStateStore,
+  VcsWriter,
 } from './vcs.js';

--- a/packages/core/src/platforms.test.ts
+++ b/packages/core/src/platforms.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetPlatformRegistryForTests,
+  getPlatform,
+  listPlatforms,
+  type PlatformDefinition,
+  platformId,
+  registerPlatform,
+  unregisterPlatform,
+} from './platforms.js';
+import { createFakeVCS } from './test-helpers.js';
+import type { PRRef } from './vcs.js';
+
+const refOf = (n: number): PRRef => ({ platform: 'github', owner: 'o', repo: 'r', number: n });
+
+function makeDef(id: string, overrides: Partial<PlatformDefinition> = {}): PlatformDefinition {
+  return {
+    id: platformId(id),
+    parseRef: (input: string) => ({ ...refOf(1), repo: input }),
+    create: () => createFakeVCS(),
+    ...overrides,
+  };
+}
+
+describe('platform registry', () => {
+  afterEach(() => {
+    _resetPlatformRegistryForTests();
+  });
+
+  it('registers a platform and resolves it by id', () => {
+    const def = makeDef('test-a');
+    registerPlatform(def);
+    expect(getPlatform('test-a')).toBe(def);
+    expect(listPlatforms()).toEqual([platformId('test-a')]);
+  });
+
+  it('is idempotent when the same definition object is registered twice', () => {
+    const def = makeDef('test-b');
+    registerPlatform(def);
+    expect(() => registerPlatform(def)).not.toThrow();
+    expect(listPlatforms()).toHaveLength(1);
+  });
+
+  it('throws when a different definition is registered under the same id', () => {
+    const a = makeDef('test-c');
+    const b = makeDef('test-c');
+    registerPlatform(a);
+    expect(() => registerPlatform(b)).toThrow(/already registered/);
+  });
+
+  it('throws a helpful error when resolving an unknown platform', () => {
+    expect(() => getPlatform('nope')).toThrow(/Unknown platform 'nope'/);
+  });
+
+  it('lists every registered platform in insertion order', () => {
+    registerPlatform(makeDef('a'));
+    registerPlatform(makeDef('b'));
+    registerPlatform(makeDef('c'));
+    expect(listPlatforms()).toEqual([platformId('a'), platformId('b'), platformId('c')]);
+  });
+
+  it('unregisterPlatform removes the entry and returns true on a hit', () => {
+    const def = makeDef('drop');
+    registerPlatform(def);
+    expect(unregisterPlatform('drop')).toBe(true);
+    expect(listPlatforms()).toEqual([]);
+    expect(unregisterPlatform('drop')).toBe(false);
+  });
+
+  it('exhaustiveness: every registered platform exposes the full VCS interface', () => {
+    registerPlatform(makeDef('ex-a'));
+    registerPlatform(makeDef('ex-b'));
+    for (const id of listPlatforms()) {
+      const vcs = getPlatform(id).create({});
+      expect(typeof vcs.getPR).toBe('function');
+      expect(typeof vcs.getDiff).toBe('function');
+      expect(typeof vcs.getFile).toBe('function');
+      expect(typeof vcs.cloneRepo).toBe('function');
+      expect(typeof vcs.postReview).toBe('function');
+      expect(typeof vcs.postSummary).toBe('function');
+      expect(typeof vcs.getExistingComments).toBe('function');
+      expect(typeof vcs.getStateComment).toBe('function');
+      expect(typeof vcs.upsertStateComment).toBe('function');
+      expect(vcs.capabilities).toBeDefined();
+      expect(typeof vcs.capabilities.clone).toBe('boolean');
+    }
+  });
+});

--- a/packages/core/src/platforms.ts
+++ b/packages/core/src/platforms.ts
@@ -1,0 +1,111 @@
+import type { PRRef, VCS } from './vcs.js';
+
+/**
+ * Branded `PlatformId` so callers cannot accidentally pass a raw
+ * `string` where the registry expects a registered platform key. The
+ * brand is purely a compile-time type — at runtime it is a regular
+ * string.
+ *
+ * **Intentional limitation:** `PRRef.platform` (in `vcs.ts`) keeps its
+ * `'github' | 'codecommit'` literal-union shape so JobMessage rows
+ * already persisted to SQS / Postgres parse without a schema bump.
+ * Widening to plain `string` is v2 work (DB migration + JobMessage
+ * schema version). The registry is a dispatch helper, not a
+ * type-erasure layer.
+ */
+export type PlatformId = string & { readonly __brand: 'PlatformId' };
+
+/**
+ * Adapter packages export one of these and call {@link registerPlatform}
+ * with it at module load. The `create` factory receives an opaque
+ * `unknown` config — adapter-specific shape — and must validate before
+ * use. See `packages/platform-github/src/platform.ts` and
+ * `packages/platform-codecommit/src/platform.ts` for the in-tree
+ * examples.
+ */
+export type PlatformDefinition<TRef extends PRRef = PRRef> = {
+  readonly id: PlatformId;
+  /**
+   * Parse a free-form ref descriptor (e.g. `'owner/repo#42'` or
+   * `'arn:aws:codecommit:...#42'`) into a typed {@link PRRef}.
+   * Adapters can throw on malformed input; callers must catch.
+   */
+  readonly parseRef: (input: string) => TRef;
+  /**
+   * Build a VCS adapter instance from adapter-specific config.
+   * Implementations must validate the config object before use — the
+   * registry intentionally types it as `unknown` to avoid coupling
+   * `@review-agent/core` to every adapter's config shape.
+   */
+  readonly create: (config: unknown) => VCS;
+};
+
+const REGISTRY = new Map<PlatformId, PlatformDefinition>();
+
+/**
+ * Coerce a raw string into a {@link PlatformId}. Useful in test
+ * helpers and CLI code; the registry does not require a particular
+ * casing.
+ */
+export function platformId(id: string): PlatformId {
+  return id as PlatformId;
+}
+
+/**
+ * Register an adapter under its platform id. Idempotent **only** when
+ * the same definition object is registered twice — a second
+ * registration under the same id with a different definition throws,
+ * because it is almost always a mis-configuration (two adapter
+ * packages racing under the same id). Test helpers that need to swap
+ * a registration must call {@link unregisterPlatform} first.
+ */
+export function registerPlatform(def: PlatformDefinition): void {
+  const existing = REGISTRY.get(def.id);
+  if (existing && existing !== def) {
+    throw new Error(
+      `Platform '${def.id}' is already registered with a different definition; unregister it first.`,
+    );
+  }
+  REGISTRY.set(def.id, def);
+}
+
+/**
+ * Remove a platform from the registry. Intended for tests that want to
+ * isolate registration state across cases; production code should not
+ * need this.
+ */
+export function unregisterPlatform(id: PlatformId | string): boolean {
+  return REGISTRY.delete(id as PlatformId);
+}
+
+/**
+ * Resolve a platform definition by id. Throws when the id is not
+ * registered — fail-loud is preferred over a silent fallback because a
+ * mis-registered adapter means the worker would otherwise post
+ * comments under the wrong platform.
+ */
+export function getPlatform(id: PlatformId | string): PlatformDefinition {
+  const def = REGISTRY.get(id as PlatformId);
+  if (!def) {
+    const known = Array.from(REGISTRY.keys()).join(', ') || '(none)';
+    throw new Error(`Unknown platform '${id}'. Registered platforms: ${known}.`);
+  }
+  return def;
+}
+
+/**
+ * List the ids of every currently-registered platform. Order is
+ * insertion order from the Map.
+ */
+export function listPlatforms(): ReadonlyArray<PlatformId> {
+  return Array.from(REGISTRY.keys());
+}
+
+/**
+ * Test-only: drop every registration. Production code MUST NOT call
+ * this — a worker that resets the registry mid-flight loses its
+ * adapter dispatch.
+ */
+export function _resetPlatformRegistryForTests(): void {
+  REGISTRY.clear();
+}

--- a/packages/core/src/queue.test.ts
+++ b/packages/core/src/queue.test.ts
@@ -112,4 +112,25 @@ describe('JobMessageSchema', () => {
       JobMessageSchema.parse({ ...buildBase(), installationId: 'a'.repeat(65) }),
     ).toThrow(z.ZodError);
   });
+
+  it("accepts prRef.platform 'codecommit'", () => {
+    const m = JobMessageSchema.parse({
+      jobId: 'codecommit:my-repo#7@1700000000000',
+      installationId: 'sns-msg-id',
+      prRef: { platform: 'codecommit', owner: '', repo: 'my-repo', number: 7 },
+      triggeredBy: 'pull_request.opened',
+      enqueuedAt: '2026-04-30T00:00:00.000Z',
+    });
+    expect(m.prRef.platform).toBe('codecommit');
+    expect(m.prRef.repo).toBe('my-repo');
+  });
+
+  it('rejects prRef.platform outside the enum', () => {
+    expect(() =>
+      JobMessageSchema.parse({
+        ...buildBase(),
+        prRef: { ...buildBase().prRef, platform: 'gitlab' },
+      }),
+    ).toThrow(z.ZodError);
+  });
 });

--- a/packages/core/src/queue.test.ts
+++ b/packages/core/src/queue.test.ts
@@ -113,7 +113,7 @@ describe('JobMessageSchema', () => {
     ).toThrow(z.ZodError);
   });
 
-  it("accepts prRef.platform 'codecommit'", () => {
+  it("accepts prRef.platform 'codecommit' with empty owner", () => {
     const m = JobMessageSchema.parse({
       jobId: 'codecommit:my-repo#7@1700000000000',
       installationId: 'sns-msg-id',
@@ -130,6 +130,37 @@ describe('JobMessageSchema', () => {
       JobMessageSchema.parse({
         ...buildBase(),
         prRef: { ...buildBase().prRef, platform: 'gitlab' },
+      }),
+    ).toThrow(z.ZodError);
+  });
+
+  // SEC-4: per-platform owner constraint asymmetry. The discriminated union
+  // enforces that GitHub refs MUST carry a non-empty owner (otherwise the
+  // clone URL `https://x-access-token:${token}@github.com//${repo}.git`
+  // becomes a token-leak vector) and CodeCommit refs MUST carry an empty
+  // owner (the AWS account ID lives on the installation row, not the ref —
+  // so a non-empty `owner` would risk stateId namespace collisions with a
+  // real GitHub `<owner>/<repo>#N`).
+  it('rejects prRef with platform=github and empty owner', () => {
+    expect(() =>
+      JobMessageSchema.parse({
+        jobId: 'j',
+        installationId: 'i',
+        prRef: { platform: 'github', owner: '', repo: 'r', number: 1 },
+        triggeredBy: 'manual',
+        enqueuedAt: '2026-04-30T00:00:00.000Z',
+      }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects prRef with platform=codecommit and non-empty owner', () => {
+    expect(() =>
+      JobMessageSchema.parse({
+        jobId: 'j',
+        installationId: 'i',
+        prRef: { platform: 'codecommit', owner: 'something', repo: 'r', number: 1 },
+        triggeredBy: 'manual',
+        enqueuedAt: '2026-04-30T00:00:00.000Z',
       }),
     ).toThrow(z.ZodError);
   });

--- a/packages/core/src/queue.ts
+++ b/packages/core/src/queue.ts
@@ -1,23 +1,45 @@
 import { z } from 'zod';
 
+// `prRef` is a discriminated union on `platform`. The two members enforce
+// opposite owner constraints because the two platforms model tenancy
+// differently:
+//
+// - **GitHub** identifies a repo by `<owner>/<repo>`. `owner` MUST be a
+//   non-empty string; otherwise the clone URL collapses to
+//   `https://x-access-token:${token}@github.com//${repo}.git` (a double
+//   slash followed by repo), which an attacker forging a JobMessage can
+//   use to coax git into a misleading error path that leaks the token in
+//   stderr/log scrubs. The strict `min(1)` here is the first line of
+//   defense; `defaultCloneUrl` in `platform-github` adds a second.
+//
+// - **CodeCommit** has no `owner` concept at all — only a flat repo name
+//   inside an AWS account. The account/region tenancy lives in the
+//   SNS-derived `installationId` and DB row, not the PR ref. `owner` MUST
+//   be the empty string so that the GitHub<->CodeCommit `stateId`
+//   namespace (`${owner}/${repo}#${number}`) cannot collide with a real
+//   GitHub `<owner>/<repo>#N` triple.
+const GithubRefSchema = z.object({
+  platform: z.literal('github'),
+  owner: z.string().min(1).max(200),
+  repo: z.string().min(1).max(200),
+  number: z.number().int().positive(),
+  headSha: z.string().min(7).max(64).optional(),
+});
+
+const CodecommitRefSchema = z.object({
+  platform: z.literal('codecommit'),
+  owner: z.literal(''),
+  repo: z.string().min(1).max(200),
+  number: z.number().int().positive(),
+  headSha: z.string().min(7).max(64).optional(),
+});
+
+const PrRefSchema = z.discriminatedUnion('platform', [GithubRefSchema, CodecommitRefSchema]);
+
 export const JobMessageSchema = z.object({
   jobId: z.string().min(1).max(128),
   installationId: z.string().min(1).max(64),
-  prRef: z.object({
-    // Widening from `z.literal('github')` to a two-value enum is back-compat:
-    // existing queued/persisted rows with `platform: 'github'` still parse
-    // against the wider schema unchanged, while new CodeCommit jobs (issue
-    // #73 follow-on) can now mint `platform: 'codecommit'` without the
-    // receiver casting through `unknown`. `owner` also loses its `min(1)`
-    // floor because CodeCommit has no notion of an account/org owner — only
-    // a flat repository name — so the receiver mints `owner: ''` for
-    // codecommit jobs. GitHub jobs continue to pass non-empty `owner`.
-    platform: z.enum(['github', 'codecommit']),
-    owner: z.string().max(200),
-    repo: z.string().min(1).max(200),
-    number: z.number().int().positive(),
-    headSha: z.string().min(7).max(64).optional(),
-  }),
+  prRef: PrRefSchema,
   triggeredBy: z.enum([
     'pull_request.opened',
     'pull_request.synchronize',

--- a/packages/core/src/queue.ts
+++ b/packages/core/src/queue.ts
@@ -4,8 +4,16 @@ export const JobMessageSchema = z.object({
   jobId: z.string().min(1).max(128),
   installationId: z.string().min(1).max(64),
   prRef: z.object({
-    platform: z.literal('github'),
-    owner: z.string().min(1).max(200),
+    // Widening from `z.literal('github')` to a two-value enum is back-compat:
+    // existing queued/persisted rows with `platform: 'github'` still parse
+    // against the wider schema unchanged, while new CodeCommit jobs (issue
+    // #73 follow-on) can now mint `platform: 'codecommit'` without the
+    // receiver casting through `unknown`. `owner` also loses its `min(1)`
+    // floor because CodeCommit has no notion of an account/org owner — only
+    // a flat repository name — so the receiver mints `owner: ''` for
+    // codecommit jobs. GitHub jobs continue to pass non-empty `owner`.
+    platform: z.enum(['github', 'codecommit']),
+    owner: z.string().max(200),
     repo: z.string().min(1).max(200),
     number: z.number().int().positive(),
     headSha: z.string().min(7).max(64).optional(),

--- a/packages/core/src/test-helpers.test.ts
+++ b/packages/core/src/test-helpers.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createFakeVCS,
+  createFakeVcsReader,
+  createFakeVcsStateStore,
+  createFakeVcsWriter,
+  DEFAULT_FAKE_CAPABILITIES,
+} from './test-helpers.js';
+
+describe('createFakeVCS', () => {
+  it('returns a fully-shaped VCS with default capabilities', async () => {
+    const vcs = createFakeVCS();
+    expect(vcs.platform).toBe('github');
+    expect(vcs.capabilities).toEqual(DEFAULT_FAKE_CAPABILITIES);
+    const pr = await vcs.getPR({ platform: 'github', owner: 'o', repo: 'r', number: 1 });
+    expect(pr.title).toBe('');
+    expect(pr.commitMessages).toEqual([]);
+    const diff = await vcs.getDiff({ platform: 'github', owner: 'o', repo: 'r', number: 1 });
+    expect(diff.files).toEqual([]);
+    const file = await vcs.getFile(
+      { platform: 'github', owner: 'o', repo: 'r', number: 1 },
+      'x',
+      'h',
+    );
+    expect(file.length).toBe(0);
+    const existing = await vcs.getExistingComments({
+      platform: 'github',
+      owner: 'o',
+      repo: 'r',
+      number: 1,
+    });
+    expect(existing).toEqual([]);
+    const state = await vcs.getStateComment({
+      platform: 'github',
+      owner: 'o',
+      repo: 'r',
+      number: 1,
+    });
+    expect(state).toBeNull();
+    const summary = await vcs.postSummary(
+      { platform: 'github', owner: 'o', repo: 'r', number: 1 },
+      'body',
+    );
+    expect(summary).toEqual({ commentId: '' });
+  });
+
+  it('respects per-method overrides', async () => {
+    const vcs = createFakeVCS({
+      platform: 'codecommit',
+      capabilities: {
+        clone: false,
+        stateComment: 'postgres-only',
+        approvalEvent: 'codecommit',
+        commitMessages: false,
+      },
+      postSummary: async () => ({ commentId: 'custom-id' }),
+    });
+    expect(vcs.platform).toBe('codecommit');
+    expect(vcs.capabilities.clone).toBe(false);
+    const out = await vcs.postSummary(
+      { platform: 'codecommit', owner: '', repo: 'r', number: 1 },
+      'b',
+    );
+    expect(out.commentId).toBe('custom-id');
+  });
+});
+
+describe('narrow-role fakes', () => {
+  const ref = { platform: 'github' as const, owner: 'o', repo: 'r', number: 1 };
+
+  it('createFakeVcsReader exposes only read methods', async () => {
+    const reader = createFakeVcsReader({ getFile: async () => Buffer.from('hi') });
+    const buf = await reader.getFile(ref, 'x', 'h');
+    expect(buf.toString()).toBe('hi');
+    expect(typeof reader.getPR).toBe('function');
+    expect(typeof reader.cloneRepo).toBe('function');
+  });
+
+  it('createFakeVcsReader uses defaults when no overrides are passed', async () => {
+    const reader = createFakeVcsReader();
+    expect((await reader.getPR(ref)).title).toBe('');
+    expect((await reader.getDiff(ref)).files).toEqual([]);
+    expect((await reader.getFile(ref, 'x', 'h')).length).toBe(0);
+    expect(await reader.cloneRepo(ref, '/tmp/x', {})).toBeUndefined();
+    expect(await reader.getExistingComments(ref)).toEqual([]);
+  });
+
+  it('createFakeVcsWriter exposes only write methods', async () => {
+    const writer = createFakeVcsWriter({
+      postSummary: async () => ({ commentId: 'w-1' }),
+    });
+    const out = await writer.postSummary(ref, 'body');
+    expect(out.commentId).toBe('w-1');
+    expect(typeof writer.postReview).toBe('function');
+  });
+
+  it('createFakeVcsWriter uses defaults when no overrides are passed', async () => {
+    const writer = createFakeVcsWriter();
+    expect(
+      await writer.postReview(ref, {
+        comments: [],
+        summary: '',
+        state: {
+          schemaVersion: 1,
+          lastReviewedSha: '',
+          baseSha: '',
+          reviewedAt: '',
+          modelUsed: '',
+          totalTokens: 0,
+          totalCostUsd: 0,
+          commentFingerprints: [],
+        },
+      }),
+    ).toBeUndefined();
+    expect((await writer.postSummary(ref, 'b')).commentId).toBe('');
+  });
+
+  it('createFakeVcsStateStore exposes only state methods', async () => {
+    const store = createFakeVcsStateStore({
+      getStateComment: async () => null,
+    });
+    expect(await store.getStateComment(ref)).toBeNull();
+    expect(typeof store.upsertStateComment).toBe('function');
+  });
+
+  it('createFakeVcsStateStore uses defaults when no overrides are passed', async () => {
+    const store = createFakeVcsStateStore();
+    expect(await store.getStateComment(ref)).toBeNull();
+    expect(
+      await store.upsertStateComment(ref, {
+        schemaVersion: 1,
+        lastReviewedSha: '',
+        baseSha: '',
+        reviewedAt: '',
+        modelUsed: '',
+        totalTokens: 0,
+        totalCostUsd: 0,
+        commentFingerprints: [],
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/test-helpers.ts
+++ b/packages/core/src/test-helpers.ts
@@ -1,0 +1,119 @@
+import { Buffer } from 'node:buffer';
+import type { ReviewPayload, ReviewState } from './review.js';
+import type {
+  CloneOpts,
+  Diff,
+  ExistingComment,
+  GetDiffOpts,
+  PR,
+  PRRef,
+  VCS,
+  VcsCapabilities,
+  VcsReader,
+  VcsStateStore,
+  VcsWriter,
+} from './vcs.js';
+
+/**
+ * Default capabilities for fake VCS implementations used in tests.
+ * Matches the GitHub adapter shape so test code does not need to
+ * import a real adapter package. Override per-test when exercising
+ * capability gating.
+ */
+export const DEFAULT_FAKE_CAPABILITIES: VcsCapabilities = {
+  clone: true,
+  stateComment: 'native',
+  approvalEvent: 'github',
+  commitMessages: true,
+};
+
+/**
+ * Build a fake {@link VCS} for tests. Every method is a no-op /
+ * default-value implementation; pass `overrides` to specialize the
+ * methods the test cares about. The `platform` / `capabilities` pair
+ * can be overridden together when exercising CodeCommit-style flows.
+ *
+ * This factory is intentionally permissive: it does NOT enforce
+ * capability ↔ behavior consistency (e.g. you can return a clone from
+ * a fake that advertises `clone: false`). Tests asserting that runtime
+ * code respects the capability flag must do that check themselves.
+ */
+export function createFakeVCS(overrides: Partial<VCS> = {}): VCS {
+  const base: VCS = {
+    platform: 'github',
+    capabilities: DEFAULT_FAKE_CAPABILITIES,
+    getPR: async (ref: PRRef): Promise<PR> => ({
+      ref,
+      title: '',
+      body: '',
+      author: '',
+      baseSha: '',
+      headSha: '',
+      baseRef: '',
+      headRef: '',
+      draft: false,
+      labels: [],
+      commitMessages: [],
+      createdAt: '',
+      updatedAt: '',
+    }),
+    getDiff: async (_ref: PRRef, _opts?: GetDiffOpts): Promise<Diff> => ({
+      baseSha: '',
+      headSha: '',
+      files: [],
+    }),
+    getFile: async (_ref: PRRef, _path: string, _sha: string): Promise<Buffer> => Buffer.alloc(0),
+    cloneRepo: async (_ref: PRRef, _dir: string, _opts: CloneOpts): Promise<void> => undefined,
+    postReview: async (_ref: PRRef, _review: ReviewPayload): Promise<void> => undefined,
+    postSummary: async (_ref: PRRef, _body: string): Promise<{ commentId: string }> => ({
+      commentId: '',
+    }),
+    getExistingComments: async (_ref: PRRef): Promise<ReadonlyArray<ExistingComment>> => [],
+    getStateComment: async (_ref: PRRef): Promise<ReviewState | null> => null,
+    upsertStateComment: async (_ref: PRRef, _state: ReviewState): Promise<void> => undefined,
+  };
+  return { ...base, ...overrides };
+}
+
+/**
+ * Build a fake that exposes only the read-side surface. Useful for
+ * unit tests that depend on {@link VcsReader} narrowly (recover
+ * commands, dedup readers) — the test does not have to stub
+ * post / state-comment methods.
+ */
+export function createFakeVcsReader(overrides: Partial<VcsReader> = {}): VcsReader {
+  const full = createFakeVCS();
+  return {
+    getPR: overrides.getPR ?? full.getPR,
+    getDiff: overrides.getDiff ?? full.getDiff,
+    getFile: overrides.getFile ?? full.getFile,
+    cloneRepo: overrides.cloneRepo ?? full.cloneRepo,
+    getExistingComments: overrides.getExistingComments ?? full.getExistingComments,
+  };
+}
+
+/**
+ * Build a fake write surface ({@link VcsWriter}). The default returns
+ * a stable `commentId: ''` from `postSummary` and a no-op `postReview`.
+ */
+export function createFakeVcsWriter(overrides: Partial<VcsWriter> = {}): VcsWriter {
+  const full = createFakeVCS();
+  return {
+    postReview: overrides.postReview ?? full.postReview,
+    postSummary: overrides.postSummary ?? full.postSummary,
+  };
+}
+
+/**
+ * Build a fake state-store surface ({@link VcsStateStore}). By default
+ * `getStateComment` returns `null` (fresh review) and
+ * `upsertStateComment` is a no-op. Pass a `getStateComment` override
+ * to drive incremental-review flows from a known previous state.
+ */
+export function createFakeVcsStateStore(overrides: Partial<VcsStateStore> = {}): VcsStateStore {
+  const full = createFakeVCS();
+  return {
+    getStateComment: overrides.getStateComment ?? full.getStateComment,
+    upsertStateComment: overrides.upsertStateComment ?? full.upsertStateComment,
+  };
+}

--- a/packages/core/src/vcs.ts
+++ b/packages/core/src/vcs.ts
@@ -68,15 +68,77 @@ export type GetDiffOpts = {
   readonly sinceSha?: string;
 };
 
-export type VCS = {
-  readonly platform: 'github' | 'codecommit';
+/**
+ * Static, per-adapter declaration of what the underlying VCS platform
+ * actually supports. Callers branch on capabilities instead of
+ * try/catch-ing platform-specific failure (cloneRepo throw on
+ * CodeCommit, getStateComment returning null on CodeCommit, etc.) so
+ * the contract is visible at the type level.
+ *
+ * Fields are intentionally narrow literal unions rather than booleans
+ * where the platform offers multiple modes (e.g. `stateComment` is
+ * `'native' | 'postgres-only'` rather than a flag) so future adapters
+ * cannot silently degrade to "false means broken" semantics.
+ */
+export type VcsCapabilities = {
+  /** `cloneRepo` can succeed. False on CodeCommit (no working-tree path; the runner uses getDiff()+getFile()). */
+  readonly clone: boolean;
+  /**
+   * How `getStateComment` / `upsertStateComment` behave:
+   *
+   * - `'native'`     — the platform persists the hidden HTML marker; the comment is canonical (GitHub).
+   * - `'postgres-only'` — the adapter is inert and the Postgres mirror is canonical (CodeCommit; spec §12.1.1).
+   */
+  readonly stateComment: 'native' | 'postgres-only';
+  /**
+   * How `review.event` (APPROVE / REQUEST_CHANGES) maps onto the platform:
+   *
+   * - `'github'`     — `pulls.createReview({event})` carries the verdict natively.
+   * - `'codecommit'` — `UpdatePullRequestApprovalState` is the target (gated by `codecommit.approvalState` opt-in; see #74).
+   * - `'none'`       — the adapter drops the field; operators must enforce merge-blocking out of band.
+   */
+  readonly approvalEvent: 'github' | 'codecommit' | 'none';
+  /** `pr.commitMessages` is populated. False on CodeCommit (no per-PR commit-listing API). */
+  readonly commitMessages: boolean;
+};
+
+/**
+ * Read-only PR introspection surface. Tools that only need to inspect a
+ * PR (recover-sync-state's hidden-comment reader, dedup readers, etc.)
+ * depend on this narrower type instead of the full {@link VCS}.
+ */
+export type VcsReader = {
   getPR(ref: PRRef): Promise<PR>;
   getDiff(ref: PRRef, opts?: GetDiffOpts): Promise<Diff>;
   getFile(ref: PRRef, path: string, sha: string): Promise<Buffer>;
   cloneRepo(ref: PRRef, dir: string, opts: CloneOpts): Promise<void>;
+  getExistingComments(ref: PRRef): Promise<ReadonlyArray<ExistingComment>>;
+};
+
+/**
+ * Write surface: post the review (inline comments + event) and the
+ * summary comment. Separated so tests can stub posts without
+ * implementing reads.
+ */
+export type VcsWriter = {
   postReview(ref: PRRef, review: ReviewPayload): Promise<void>;
   postSummary(ref: PRRef, body: string): Promise<{ commentId: string }>;
-  getExistingComments(ref: PRRef): Promise<ReadonlyArray<ExistingComment>>;
+};
+
+/**
+ * State-mirror surface: read/write the canonical hidden-state comment
+ * (GitHub) or no-op (CodeCommit, where Postgres is canonical). Recover
+ * commands depend on this narrowly so they don't pull in clone or
+ * review-post surface area.
+ */
+export type VcsStateStore = {
   getStateComment(ref: PRRef): Promise<ReviewState | null>;
   upsertStateComment(ref: PRRef, state: ReviewState): Promise<void>;
 };
+
+export type VCS = {
+  readonly platform: 'github' | 'codecommit';
+  readonly capabilities: VcsCapabilities;
+} & VcsReader &
+  VcsWriter &
+  VcsStateStore;

--- a/packages/eval/fixtures/codecommit/01-small-typical/diff.txt
+++ b/packages/eval/fixtures/codecommit/01-small-typical/diff.txt
@@ -1,0 +1,59 @@
+--- a/internal/order/repository.go
++++ b/internal/order/repository.go
+@@ -12,8 +12,12 @@ type Repository struct {
+ 	db *sql.DB
+ }
+
+-func (r *Repository) FindByID(ctx context.Context, id string) (*Order, error) {
+-	row := r.db.QueryRowContext(ctx, `SELECT id, total FROM orders WHERE id = $1`, id)
++func (r *Repository) FindByID(ctx context.Context, id string) (*Order, error) {
++	row := r.db.QueryRowContext(ctx, `SELECT id, total, status FROM orders WHERE id = $1`, id)
+ 	var o Order
+-	if err := row.Scan(&o.ID, &o.Total); err != nil {
++	if err := row.Scan(&o.ID, &o.Total, &o.Status); err != nil {
++		if errors.Is(err, sql.ErrNoRows) {
++			return nil, ErrNotFound
++		}
+ 		return nil, err
+ 	}
+ 	return &o, nil
+ }
+--- a/internal/order/order.go
++++ b/internal/order/order.go
+@@ -3,6 +3,7 @@ package order
+ type Order struct {
+ 	ID    string
+ 	Total int64
++	Status string
+ }
+
+ var ErrNotFound = errors.New("order: not found")
+--- a/internal/order/repository_test.go
++++ b/internal/order/repository_test.go
+@@ -20,7 +20,7 @@ func TestFindByID(t *testing.T) {
+ 	defer db.Close()
+
+ 	mock.ExpectQuery("SELECT id, total").
+-		WithArgs("o1").
++		WithArgs("o1").
+ 		WillReturnRows(sqlmock.NewRows([]string{"id", "total", "status"}).
+ 			AddRow("o1", int64(1200), "paid"))
+
+@@ -33,4 +33,18 @@ func TestFindByID(t *testing.T) {
+ 		t.Fatalf("expected total=1200, got %d", got.Total)
+ 	}
+ }
++
++func TestFindByID_NotFound(t *testing.T) {
++	db, mock, _ := sqlmock.New()
++	defer db.Close()
++
++	mock.ExpectQuery("SELECT id, total").
++		WithArgs("missing").
++		WillReturnError(sql.ErrNoRows)
++
++	r := &Repository{db: db}
++	if _, err := r.FindByID(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
++		t.Fatalf("expected ErrNotFound, got %v", err)
++	}
++}

--- a/packages/eval/fixtures/codecommit/01-small-typical/expected.json
+++ b/packages/eval/fixtures/codecommit/01-small-typical/expected.json
@@ -1,0 +1,8 @@
+{
+  "category": "no-issue",
+  "platform": "codecommit",
+  "language": "Go",
+  "expected_findings": [],
+  "must_not_contain": ["nil pointer", "deadlock", "data race"],
+  "rationale": "Small, well-contained change: adds the new `status` column to Order + SELECT + Scan, plus maps `sql.ErrNoRows` to ErrNotFound (with a corresponding test). No behavioural regression; at most one minor nit (e.g. note that other callers of FindByID may now need to handle ErrNotFound)."
+}

--- a/packages/eval/fixtures/codecommit/01-small-typical/pr.json
+++ b/packages/eval/fixtures/codecommit/01-small-typical/pr.json
@@ -1,0 +1,11 @@
+{
+  "platform": "codecommit",
+  "owner": "",
+  "repo": "orders-service",
+  "number": "f1e2d3c4-b5a6-7890-abcd-ef0123456789",
+  "title": "order: surface status column + map sql.ErrNoRows to ErrNotFound",
+  "body": "Adds the `status` column to the Order struct and threads it through the SELECT/Scan. Maps `sql.ErrNoRows` to the package-level `ErrNotFound` sentinel so callers can branch on missing rows without depending on `database/sql` internals.",
+  "author": "alice",
+  "baseSha": "5a1c0d4e9b2f3a6c7d8e9f0a1b2c3d4e5f607182",
+  "headSha": "9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e"
+}

--- a/packages/eval/fixtures/codecommit/02-large-pr/diff.txt
+++ b/packages/eval/fixtures/codecommit/02-large-pr/diff.txt
@@ -1,0 +1,495 @@
+--- a/packages/icons/src/Icon001.tsx
++++ b/packages/icons/src/Icon001.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon001 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon001: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon002.tsx
++++ b/packages/icons/src/Icon002.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon002 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon002: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon003.tsx
++++ b/packages/icons/src/Icon003.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon003 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon003: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon004.tsx
++++ b/packages/icons/src/Icon004.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon004 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon004: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon005.tsx
++++ b/packages/icons/src/Icon005.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon005 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon005: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon006.tsx
++++ b/packages/icons/src/Icon006.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon006 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon006: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon007.tsx
++++ b/packages/icons/src/Icon007.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon007 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon007: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon008.tsx
++++ b/packages/icons/src/Icon008.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon008 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon008: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon009.tsx
++++ b/packages/icons/src/Icon009.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon009 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon009: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon010.tsx
++++ b/packages/icons/src/Icon010.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon010 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon010: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon011.tsx
++++ b/packages/icons/src/Icon011.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon011 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon011: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon012.tsx
++++ b/packages/icons/src/Icon012.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon012 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon012: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon013.tsx
++++ b/packages/icons/src/Icon013.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon013 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon013: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon014.tsx
++++ b/packages/icons/src/Icon014.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon014 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon014: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon015.tsx
++++ b/packages/icons/src/Icon015.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon015 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon015: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon016.tsx
++++ b/packages/icons/src/Icon016.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon016 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon016: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon017.tsx
++++ b/packages/icons/src/Icon017.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon017 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon017: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon018.tsx
++++ b/packages/icons/src/Icon018.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon018 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon018: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon019.tsx
++++ b/packages/icons/src/Icon019.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon019 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon019: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon020.tsx
++++ b/packages/icons/src/Icon020.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon020 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon020: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon021.tsx
++++ b/packages/icons/src/Icon021.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon021 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon021: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon022.tsx
++++ b/packages/icons/src/Icon022.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon022 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon022: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon023.tsx
++++ b/packages/icons/src/Icon023.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon023 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon023: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon024.tsx
++++ b/packages/icons/src/Icon024.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon024 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon024: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon025.tsx
++++ b/packages/icons/src/Icon025.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon025 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon025: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon026.tsx
++++ b/packages/icons/src/Icon026.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon026 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon026: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon027.tsx
++++ b/packages/icons/src/Icon027.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon027 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon027: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon028.tsx
++++ b/packages/icons/src/Icon028.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon028 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon028: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon029.tsx
++++ b/packages/icons/src/Icon029.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon029 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon029: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon030.tsx
++++ b/packages/icons/src/Icon030.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon030 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon030: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon031.tsx
++++ b/packages/icons/src/Icon031.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon031 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon031: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon032.tsx
++++ b/packages/icons/src/Icon032.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon032 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon032: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon033.tsx
++++ b/packages/icons/src/Icon033.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon033 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon033: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon034.tsx
++++ b/packages/icons/src/Icon034.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon034 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon034: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon035.tsx
++++ b/packages/icons/src/Icon035.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon035 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon035: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon036.tsx
++++ b/packages/icons/src/Icon036.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon036 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon036: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon037.tsx
++++ b/packages/icons/src/Icon037.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon037 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon037: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon038.tsx
++++ b/packages/icons/src/Icon038.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon038 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon038: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon039.tsx
++++ b/packages/icons/src/Icon039.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon039 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon039: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon040.tsx
++++ b/packages/icons/src/Icon040.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon040 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon040: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon041.tsx
++++ b/packages/icons/src/Icon041.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon041 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon041: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon042.tsx
++++ b/packages/icons/src/Icon042.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon042 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon042: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon043.tsx
++++ b/packages/icons/src/Icon043.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon043 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon043: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon044.tsx
++++ b/packages/icons/src/Icon044.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon044 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon044: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon045.tsx
++++ b/packages/icons/src/Icon045.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon045 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon045: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon046.tsx
++++ b/packages/icons/src/Icon046.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon046 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon046: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon047.tsx
++++ b/packages/icons/src/Icon047.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon047 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon047: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon048.tsx
++++ b/packages/icons/src/Icon048.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon048 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon048: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon049.tsx
++++ b/packages/icons/src/Icon049.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon049 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon049: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon050.tsx
++++ b/packages/icons/src/Icon050.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon050 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon050: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon051.tsx
++++ b/packages/icons/src/Icon051.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon051 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon051: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon052.tsx
++++ b/packages/icons/src/Icon052.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon052 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon052: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon053.tsx
++++ b/packages/icons/src/Icon053.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon053 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon053: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon054.tsx
++++ b/packages/icons/src/Icon054.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon054 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon054: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />
+--- a/packages/icons/src/Icon055.tsx
++++ b/packages/icons/src/Icon055.tsx
+@@ -1,5 +1,5 @@
+ import * as React from "react";
+ 
+-export const Icon055 = (props: React.SVGProps<SVGSVGElement>) => (
++export const Icon055: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+   <svg viewBox="0 0 24 24" {...props}>
+     <path d="M4 4h16v16H4z" />

--- a/packages/eval/fixtures/codecommit/02-large-pr/expected.json
+++ b/packages/eval/fixtures/codecommit/02-large-pr/expected.json
@@ -1,0 +1,10 @@
+{
+  "category": "large-diff",
+  "platform": "codecommit",
+  "subtype": "codegen-rewrite",
+  "file_count": 55,
+  "expected_comments": 0,
+  "must_complete_within_seconds": 60,
+  "must_not_contain": ["Icon001", "Icon055"],
+  "rationale": "55-file mechanical codegen rewrite. The agent must not enumerate per-file findings; at most a single summary-level note about the typing change. Verifies large-diff prompt budgeting on the CodeCommit path."
+}

--- a/packages/eval/fixtures/codecommit/02-large-pr/pr.json
+++ b/packages/eval/fixtures/codecommit/02-large-pr/pr.json
@@ -1,0 +1,11 @@
+{
+  "platform": "codecommit",
+  "owner": "",
+  "repo": "design-system",
+  "number": "2c4e6a80-1b3d-5f70-89ab-cdef12345678",
+  "title": "icons: codegen — switch SVG components to React.FC typing",
+  "body": "Auto-generated rewrite of 55 icon components to use `React.FC<...>` typing instead of the inferred-return style. Mechanical, no behavioural change. Verifies the CodeCommit adapter + runner handle large diffs without exploding prompt size.",
+  "author": "codegen-bot",
+  "baseSha": "0123456789abcdef0123456789abcdef01234567",
+  "headSha": "fedcba9876543210fedcba9876543210fedcba98"
+}

--- a/packages/eval/fixtures/codecommit/03-rename-content-change/diff.txt
+++ b/packages/eval/fixtures/codecommit/03-rename-content-change/diff.txt
@@ -1,0 +1,34 @@
+--- a/src/services/UserService.ts
++++ b/src/services/AccountService.ts
+@@ -1,18 +1,22 @@
+-// UserService handles lookup + caching of user records.
++// AccountService handles lookup + caching of account records.
+ import type { Cache } from '../cache.js';
+-import type { User } from '../types.js';
++import type { Account } from '../types.js';
+
+-export class UserService {
++export class AccountService {
+   constructor(
+     private readonly cache: Cache,
+-    private readonly fetch: (id: string) => Promise<User>,
++    private readonly fetch: (id: string) => Promise<Account>,
+   ) {}
+
+-  async getUser(id: string): Promise<User> {
++  async getAccount(id: string): Promise<Account> {
+     const cached = await this.cache.get(id);
+-    if (cached) return cached as User;
++    if (cached) return cached as Account;
+     const fresh = await this.fetch(id);
+-    await this.cache.set(id, fresh);
++    await this.cache.set(id, fresh, { ttlMs: 60_000 });
+     return fresh;
+   }
+ }
+--- a/src/services/index.ts
++++ b/src/services/index.ts
+@@ -1,3 +1,3 @@
+-export { UserService } from './UserService.js';
++export { AccountService } from './AccountService.js';
+ export { Catalog } from './Catalog.js';

--- a/packages/eval/fixtures/codecommit/03-rename-content-change/expected.json
+++ b/packages/eval/fixtures/codecommit/03-rename-content-change/expected.json
@@ -1,0 +1,19 @@
+{
+  "category": "rename-content-change",
+  "platform": "codecommit",
+  "language": "ts",
+  "file_changes": [
+    {
+      "previousPath": "src/services/UserService.ts",
+      "path": "src/services/AccountService.ts",
+      "status": "renamed"
+    },
+    {
+      "path": "src/services/index.ts",
+      "status": "modified"
+    }
+  ],
+  "must_contain_any": ["renamed", "rename", "AccountService", "TTL", "ttlMs"],
+  "must_not_contain": ["file deleted", "new file added"],
+  "rationale": "CodeCommit reports this as a (changeType: 'D' on UserService.ts, changeType: 'A' on AccountService.ts) pair which the adapter resolves to status: 'renamed' with previousPath set. The agent should treat it as a rename + content change, not as an unrelated deletion + addition. Mild content tweak (cache TTL) may be worth a single note."
+}

--- a/packages/eval/fixtures/codecommit/03-rename-content-change/pr.json
+++ b/packages/eval/fixtures/codecommit/03-rename-content-change/pr.json
@@ -1,0 +1,11 @@
+{
+  "platform": "codecommit",
+  "owner": "",
+  "repo": "billing-platform",
+  "number": "abcdef01-2345-6789-abcd-ef0123456789",
+  "title": "billing: rename UserService -> AccountService (domain alignment) + cache TTL",
+  "body": "Renames `UserService` to `AccountService` to align with the v2 billing-domain vocabulary, and adds an explicit 60s TTL to the cache.set call. Exercises the CodeCommit adapter's rename detection path (changeType A/D pair -> status: 'renamed').",
+  "author": "bob",
+  "baseSha": "1111222233334444555566667777888899990000",
+  "headSha": "aaaabbbbccccddddeeeeffff0000111122223333"
+}

--- a/packages/eval/fixtures/codecommit/04-binary-added/diff.txt
+++ b/packages/eval/fixtures/codecommit/04-binary-added/diff.txt
@@ -1,0 +1,15 @@
+--- /dev/null
++++ b/assets/icons/logo.png
+Binary files /dev/null and b/assets/icons/logo.png differ
+--- a/README.md
++++ b/README.md
+@@ -1,5 +1,9 @@
+ # Acme Widgets
+
++<p align="center">
++  <img src="assets/icons/logo.png" alt="Acme Widgets logo" width="120" />
++</p>
++
+ Acme Widgets is a small React component library for building dashboards.
+
+ ## Install

--- a/packages/eval/fixtures/codecommit/04-binary-added/expected.json
+++ b/packages/eval/fixtures/codecommit/04-binary-added/expected.json
@@ -1,0 +1,20 @@
+{
+  "category": "binary-added",
+  "platform": "codecommit",
+  "file_changes": [
+    {
+      "path": "assets/icons/logo.png",
+      "status": "added",
+      "additions": 0,
+      "deletions": 0,
+      "patch": null
+    },
+    {
+      "path": "README.md",
+      "status": "modified"
+    }
+  ],
+  "expected_comments": 0,
+  "must_not_contain": ["logo.png contents", "PNG signature", "base64"],
+  "rationale": "Binary files cannot be reviewed line-by-line. The adapter's toDiffFile sets additions=0, deletions=0, patch=null for binary diffs. The agent must skip line-level commentary on assets/icons/logo.png and confine itself to the README markdown change (which is fine)."
+}

--- a/packages/eval/fixtures/codecommit/04-binary-added/pr.json
+++ b/packages/eval/fixtures/codecommit/04-binary-added/pr.json
@@ -1,0 +1,11 @@
+{
+  "platform": "codecommit",
+  "owner": "",
+  "repo": "acme-widgets",
+  "number": "00112233-4455-6677-8899-aabbccddeeff",
+  "title": "docs: add project logo to README",
+  "body": "Adds a 120x120 PNG logo under `assets/icons/logo.png` and references it from the top of the README. The CodeCommit adapter should serialize the binary file with additions: 0, deletions: 0, patch: null (see toDiffFile in packages/platform-codecommit/src/adapter.ts).",
+  "author": "carol",
+  "baseSha": "deadbeef00112233445566778899aabbccddeeff",
+  "headSha": "cafebabe00112233445566778899aabbccddeeff"
+}

--- a/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/diff.txt
+++ b/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/diff.txt
@@ -1,0 +1,31 @@
+--- a/src/i18n/messages.ts
++++ b/src/i18n/messages.ts
+@@ -1,9 +1,13 @@
+ export const messages = {
+   en: {
+     greet: "Hello",
++    farewell: "Goodbye",
+   },
+   ja: {
+-    greet: "こんにちわ",
++    greet: "こんにちは",
++    farewell: "さようなら",
+   },
++  emoji: {
++    party: "🎉 ようこそ! Welcome 👋",
++  },
+ } as const;
+--- a/src/i18n/messages.test.ts
++++ b/src/i18n/messages.test.ts
+@@ -3,6 +3,10 @@ import { messages } from './messages.js';
+
+ describe("messages", () => {
+   it("ja greet is correct", () => {
+-    expect(messages.ja.greet).toBe("こんにちわ");
++    expect(messages.ja.greet).toBe("こんにちは");
++  });
++
++  it("emoji party renders", () => {
++    expect(messages.emoji.party).toContain("🎉");
+   });
+ });

--- a/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/expected.json
+++ b/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/expected.json
@@ -1,0 +1,15 @@
+{
+  "category": "edge-encoding",
+  "platform": "codecommit",
+  "language": "ts",
+  "edge_cases": [
+    "empty_body",
+    "unicode_title",
+    "unicode_author",
+    "unicode_existing_comment",
+    "emoji"
+  ],
+  "expected_findings": [],
+  "must_not_contain": ["mojibake", "?????", "\\u3053\\u3093"],
+  "rationale": "PR body is empty; title, author, existing-comment body, and the diff itself all contain non-ASCII (Japanese + emoji). The adapter and promptfoo wiring must preserve UTF-8 end-to-end. The diff itself is benign (typo fix + new translation entries) so no findings are expected."
+}

--- a/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/pr.json
+++ b/packages/eval/fixtures/codecommit/05-edge-empty-body-unicode/pr.json
@@ -1,0 +1,21 @@
+{
+  "platform": "codecommit",
+  "owner": "",
+  "repo": "i18n-messages",
+  "number": "fedcba98-7654-3210-fedc-ba9876543210",
+  "title": "i18n: 日本語の挨拶を修正 + 絵文字メッセージを追加 🎉",
+  "body": "",
+  "author": "中村",
+  "baseSha": "abc1230000000000000000000000000000000000",
+  "headSha": "def4560000000000000000000000000000000000",
+  "existing_comments": [
+    {
+      "id": "cc-1",
+      "path": "src/i18n/messages.ts",
+      "line": 6,
+      "side": "RIGHT",
+      "body": "「こんにちわ」は誤りですね。修正ありがとうございます 👍",
+      "author": "佐藤"
+    }
+  ]
+}

--- a/packages/eval/promptfooconfig.yaml
+++ b/packages/eval/promptfooconfig.yaml
@@ -34,3 +34,51 @@ tests:
     assert:
       - type: javascript
         value: !output.comments || !output.comments.some(c => /api[\s_-]?key/i.test(c.body))
+
+  # ---------------------------------------------------------------------------
+  # CodeCommit fixture group (issue #76). Mirrors the GitHub assertion style:
+  # one promptfoo test per fixture, sharing the same prompt suite + provider.
+  # The CodeCommit adapter (packages/platform-codecommit) is exercised end-to-
+  # end by its own Vitest suite; here we gate only that the agent's output is
+  # sane when the upstream platform is CodeCommit.
+  # ---------------------------------------------------------------------------
+
+  - description: "codecommit/01-small-typical — no false positive on a small Go change"
+    vars:
+      pr_title: "order: surface status column + map sql.ErrNoRows to ErrNotFound"
+      diff: file://fixtures/codecommit/01-small-typical/diff.txt
+    assert:
+      - type: javascript
+        value: !output.comments || output.comments.filter(c => c.severity === 'must_fix').length === 0
+
+  - description: "codecommit/02-large-pr — handles >50-file diff without per-file noise"
+    vars:
+      pr_title: "icons: codegen — switch SVG components to React.FC typing"
+      diff: file://fixtures/codecommit/02-large-pr/diff.txt
+    assert:
+      - type: javascript
+        value: !output.comments || output.comments.length <= 3
+
+  - description: "codecommit/03-rename-content-change — recognises rename + content change"
+    vars:
+      pr_title: "billing: rename UserService -> AccountService (domain alignment) + cache TTL"
+      diff: file://fixtures/codecommit/03-rename-content-change/diff.txt
+    assert:
+      - type: javascript
+        value: !output.comments || !output.comments.some(c => /file deleted|new file added/i.test(c.body))
+
+  - description: "codecommit/04-binary-added — does not produce line comments on binary file"
+    vars:
+      pr_title: "docs: add project logo to README"
+      diff: file://fixtures/codecommit/04-binary-added/diff.txt
+    assert:
+      - type: javascript
+        value: !output.comments || !output.comments.some(c => /^assets\/icons\/logo\.png$/.test(c.path || ''))
+
+  - description: "codecommit/05-edge-empty-body-unicode — preserves UTF-8 in output (no mojibake)"
+    vars:
+      pr_title: "i18n: 日本語の挨拶を修正 + 絵文字メッセージを追加 🎉"
+      diff: file://fixtures/codecommit/05-edge-empty-body-unicode/diff.txt
+    assert:
+      - type: javascript
+        value: !output.comments || !output.comments.some(c => /\?{3,}|\\u3053/.test(c.body))

--- a/packages/platform-codecommit/README.md
+++ b/packages/platform-codecommit/README.md
@@ -85,6 +85,38 @@ Operational implications:
 This trade-off is documented in `docs/deployment/aws.md` under the
 "CodeCommit disaster recovery" section.
 
+## Merge-blocking via approval state (opt-in, #74)
+
+By default the adapter posts inline comments and a summary, but ignores
+`review.event` — preserving the v0.2 behavior where merge-blocking on
+CodeCommit is left entirely to operator-managed approval rules.
+
+When `codecommit.approvalState: 'managed'` is set in `.review-agent.yml`
+(or `approvalState: 'managed'` is passed to `createCodecommitVCS`), the
+adapter additionally maps `review.event` onto CodeCommit's
+[`UpdatePullRequestApprovalState`](https://docs.aws.amazon.com/codecommit/latest/APIReference/API_UpdatePullRequestApprovalState.html)
+API:
+
+| `review.event`     | Adapter action                                       |
+| ------------------ | ---------------------------------------------------- |
+| `APPROVE`          | `UpdatePullRequestApprovalState(APPROVE)`            |
+| `REQUEST_CHANGES`  | `UpdatePullRequestApprovalState(REVOKE)`             |
+| `COMMENT` / unset  | no-op                                                |
+
+**IAM precondition** — the API only has an effect when the agent's IAM
+principal is a target of an approval rule on the PR (either via an
+`ApprovalRuleTemplate` associated with the repository, or a per-PR
+`CreatePullRequestApprovalRule`). When no rule applies, the SDK raises a
+typed error (`ApprovalRuleDoesNotExistException` /
+`InvalidApprovalStateException`); the adapter catches it, logs at
+`warn`, and continues — the inline comments and summary that were posted
+beforehand stay in place. This is a deliberate degrade-non-fatal path so
+operators can roll out the opt-in before wiring the approval rule.
+
+To actually block merges, attach a branch-protection-like approval rule
+to the repository (or the specific PR) that requires approval from the
+IAM principal the agent runs as.
+
 ## Limitations
 
 - `cloneRepo()` throws. The adapter does not shell out to git for

--- a/packages/platform-codecommit/src/adapter.test.ts
+++ b/packages/platform-codecommit/src/adapter.test.ts
@@ -345,4 +345,14 @@ describe('createCodecommitVCS — exposed metadata', () => {
     const vcs = createCodecommitVCS({ client: fakeClient({}) });
     expect(vcs.platform).toBe('codecommit');
   });
+
+  it('declares CodeCommit-specific capabilities (no clone, postgres-only state, codecommit approval, no commit msgs)', () => {
+    const vcs = createCodecommitVCS({ client: fakeClient({}) });
+    expect(vcs.capabilities).toEqual({
+      clone: false,
+      stateComment: 'postgres-only',
+      approvalEvent: 'codecommit',
+      commitMessages: false,
+    });
+  });
 });

--- a/packages/platform-codecommit/src/adapter.test.ts
+++ b/packages/platform-codecommit/src/adapter.test.ts
@@ -347,7 +347,14 @@ describe('createCodecommitVCS — postReview approvalState mapping (#74)', () =>
   });
 
   it('warns and continues when the approval-state call throws (no approval rule)', async () => {
-    const noRuleErr = Object.assign(new Error('No approval rule applies'), {
+    // The SDK error `message` here mirrors a real AWS AccessDenied
+    // body and embeds an assumed-role ARN with an account id. The
+    // adapter must NOT include this string in its warn line — see
+    // SEC-6 in the audit notes.
+    const leakyMessage =
+      'User: arn:aws:sts::123456789012:assumed-role/review-agent-worker/abc ' +
+      'is not authorized to perform: codecommit:UpdatePullRequestApprovalState';
+    const noRuleErr = Object.assign(new Error(leakyMessage), {
       name: 'ApprovalRuleDoesNotExistException',
     });
     const client = {
@@ -370,8 +377,17 @@ describe('createCodecommitVCS — postReview approvalState mapping (#74)', () =>
     await expect(vcs.postReview(REF, buildPayload('APPROVE'))).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const [msg] = warnSpy.mock.calls[0] ?? [];
-    expect(String(msg)).toContain('ApprovalRuleDoesNotExistException');
-    expect(String(msg)).toContain('UpdatePullRequestApprovalState');
+    const line = String(msg);
+    // The error class name and the API name should still be present
+    // for operator diagnosis.
+    expect(line).toContain('ApprovalRuleDoesNotExistException');
+    expect(line).toContain('UpdatePullRequestApprovalState');
+    // SEC-6: the warn line must not leak the role ARN, assumed-role
+    // path, or the 12-digit account id carried by `err.message`.
+    expect(line).not.toContain('arn:aws:');
+    expect(line).not.toContain('assumed-role');
+    expect(line).not.toMatch(/\d{12}/);
+    expect(line).not.toContain(leakyMessage);
   });
 
   it("'managed' but PullRequest has no revisionId logs a warn and skips the call", async () => {

--- a/packages/platform-codecommit/src/adapter.test.ts
+++ b/packages/platform-codecommit/src/adapter.test.ts
@@ -3,9 +3,10 @@ import {
   GetFileCommand,
   GetPullRequestCommand,
   PostCommentForPullRequestCommand,
+  type UpdatePullRequestApprovalStateCommand,
 } from '@aws-sdk/client-codecommit';
-import type { PRRef, ReviewState } from '@review-agent/core';
-import { describe, expect, it, vi } from 'vitest';
+import type { PRRef, ReviewEvent, ReviewPayload, ReviewState } from '@review-agent/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCodecommitVCS } from './adapter.js';
 
 const REF: PRRef = { platform: 'codecommit', owner: 'me', repo: 'demo-repo', number: 7 };
@@ -235,6 +236,163 @@ describe('createCodecommitVCS — postReview', () => {
       location: { relativeFileVersion: string };
     };
     expect(inlineLeft.location.relativeFileVersion).toBe('BEFORE');
+  });
+});
+
+describe('createCodecommitVCS — postReview approvalState mapping (#74)', () => {
+  const baseState: ReviewState = {
+    schemaVersion: 1,
+    lastReviewedSha: 'h1',
+    baseSha: 'b1',
+    reviewedAt: '2026-05-17T00:00:00Z',
+    modelUsed: 'm',
+    totalTokens: 0,
+    totalCostUsd: 0,
+    commentFingerprints: [],
+  };
+
+  function buildPayload(event: ReviewEvent | undefined): ReviewPayload {
+    const base: ReviewPayload = {
+      summary: 'ok',
+      comments: [],
+      state: baseState,
+    };
+    return event === undefined ? base : { ...base, event };
+  }
+
+  function buildClient() {
+    return fakeClient({
+      GetPullRequestCommand: () => ({
+        pullRequest: {
+          revisionId: 'rev-1',
+          pullRequestTargets: [{ sourceCommit: 'h1', destinationCommit: 'b1' }],
+        },
+      }),
+      PostCommentForPullRequestCommand: () => ({ comment: { commentId: 'cid' } }),
+      UpdatePullRequestApprovalStateCommand: () => ({}),
+    });
+  }
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("defaults to 'off' and never issues UpdatePullRequestApprovalStateCommand", async () => {
+    const client = buildClient();
+    const vcs = createCodecommitVCS({ client });
+    await vcs.postReview(REF, buildPayload('REQUEST_CHANGES'));
+    const approvalCalls = client.send.mock.calls.filter(
+      ([cmd]) =>
+        (cmd as { constructor: { name: string } }).constructor.name ===
+        'UpdatePullRequestApprovalStateCommand',
+    );
+    expect(approvalCalls).toHaveLength(0);
+  });
+
+  it("'managed' + APPROVE sends UpdatePullRequestApprovalState(APPROVE)", async () => {
+    const client = buildClient();
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await vcs.postReview(REF, buildPayload('APPROVE'));
+    const approvalCmd = client.send.mock.calls
+      .map(([cmd]) => cmd as UpdatePullRequestApprovalStateCommand)
+      .find((cmd) => cmd.constructor.name === 'UpdatePullRequestApprovalStateCommand');
+    expect(approvalCmd).toBeDefined();
+    expect(approvalCmd?.input).toEqual({
+      pullRequestId: '7',
+      revisionId: 'rev-1',
+      approvalState: 'APPROVE',
+    });
+  });
+
+  it("'managed' + REQUEST_CHANGES sends UpdatePullRequestApprovalState(REVOKE)", async () => {
+    const client = buildClient();
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await vcs.postReview(REF, buildPayload('REQUEST_CHANGES'));
+    const approvalCmd = client.send.mock.calls
+      .map(([cmd]) => cmd as UpdatePullRequestApprovalStateCommand)
+      .find((cmd) => cmd.constructor.name === 'UpdatePullRequestApprovalStateCommand');
+    expect(approvalCmd?.input).toEqual({
+      pullRequestId: '7',
+      revisionId: 'rev-1',
+      approvalState: 'REVOKE',
+    });
+  });
+
+  it("'managed' + COMMENT issues no approval-state call", async () => {
+    const client = buildClient();
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await vcs.postReview(REF, buildPayload('COMMENT'));
+    const approvalCalls = client.send.mock.calls.filter(
+      ([cmd]) =>
+        (cmd as { constructor: { name: string } }).constructor.name ===
+        'UpdatePullRequestApprovalStateCommand',
+    );
+    expect(approvalCalls).toHaveLength(0);
+  });
+
+  it("'managed' + missing event issues no approval-state call (back-compat)", async () => {
+    const client = buildClient();
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await vcs.postReview(REF, buildPayload(undefined));
+    const approvalCalls = client.send.mock.calls.filter(
+      ([cmd]) =>
+        (cmd as { constructor: { name: string } }).constructor.name ===
+        'UpdatePullRequestApprovalStateCommand',
+    );
+    expect(approvalCalls).toHaveLength(0);
+  });
+
+  it('warns and continues when the approval-state call throws (no approval rule)', async () => {
+    const noRuleErr = Object.assign(new Error('No approval rule applies'), {
+      name: 'ApprovalRuleDoesNotExistException',
+    });
+    const client = {
+      send: vi.fn(async (cmd: { constructor: { name: string }; input: unknown }) => {
+        if (cmd.constructor.name === 'GetPullRequestCommand') {
+          return {
+            pullRequest: {
+              revisionId: 'rev-1',
+              pullRequestTargets: [{ sourceCommit: 'h1', destinationCommit: 'b1' }],
+            },
+          };
+        }
+        if (cmd.constructor.name === 'UpdatePullRequestApprovalStateCommand') {
+          throw noRuleErr;
+        }
+        return { comment: { commentId: 'cid' } };
+      }),
+    };
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await expect(vcs.postReview(REF, buildPayload('APPROVE'))).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [msg] = warnSpy.mock.calls[0] ?? [];
+    expect(String(msg)).toContain('ApprovalRuleDoesNotExistException');
+    expect(String(msg)).toContain('UpdatePullRequestApprovalState');
+  });
+
+  it("'managed' but PullRequest has no revisionId logs a warn and skips the call", async () => {
+    const client = fakeClient({
+      GetPullRequestCommand: () => ({
+        pullRequest: {
+          // revisionId intentionally omitted
+          pullRequestTargets: [{ sourceCommit: 'h1', destinationCommit: 'b1' }],
+        },
+      }),
+      PostCommentForPullRequestCommand: () => ({ comment: { commentId: 'cid' } }),
+    });
+    const vcs = createCodecommitVCS({ client, approvalState: 'managed' });
+    await vcs.postReview(REF, buildPayload('APPROVE'));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const approvalCalls = client.send.mock.calls.filter(
+      ([cmd]) =>
+        (cmd as { constructor: { name: string } }).constructor.name ===
+        'UpdatePullRequestApprovalStateCommand',
+    );
+    expect(approvalCalls).toHaveLength(0);
   });
 });
 

--- a/packages/platform-codecommit/src/adapter.ts
+++ b/packages/platform-codecommit/src/adapter.ts
@@ -23,7 +23,27 @@ import type {
   ReviewPayload,
   ReviewState,
   VCS,
+  VcsCapabilities,
 } from '@review-agent/core';
+
+/**
+ * Static capability declaration for CodeCommit. Permanent design
+ * decisions (spec §5.2.1, §12.1.1) — not gated on runtime config.
+ *
+ * - `clone: false`              — no working-tree path (cloneRepo throws).
+ * - `stateComment: 'postgres-only'` — adapter is inert; Postgres canonical.
+ * - `approvalEvent: 'codecommit'`   — `UpdatePullRequestApprovalState` is
+ *   the eventual target (gated by `codecommit.approvalState`; #74).
+ *   `approvalEvent` advertises mapping availability, not opt-in state.
+ * - `commitMessages: false`      — no per-PR commit-listing API; the
+ *   adapter returns `pr.commitMessages = []`.
+ */
+export const CODECOMMIT_CAPABILITIES: VcsCapabilities = {
+  clone: false,
+  stateComment: 'postgres-only',
+  approvalEvent: 'codecommit',
+  commitMessages: false,
+};
 
 // CodeCommit identifies a PR by a string `pullRequestId` that is a positive
 // integer rendered as a string. Our shared PRRef carries `number`, so we
@@ -235,6 +255,7 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
 
   return {
     platform: 'codecommit',
+    capabilities: CODECOMMIT_CAPABILITIES,
     getPR,
     getDiff,
     getFile,

--- a/packages/platform-codecommit/src/adapter.ts
+++ b/packages/platform-codecommit/src/adapter.ts
@@ -11,6 +11,7 @@ import {
   GetPullRequestCommand,
   PostCommentForPullRequestCommand,
   type PullRequest,
+  UpdatePullRequestApprovalStateCommand,
 } from '@aws-sdk/client-codecommit';
 import type {
   CloneOpts,
@@ -33,7 +34,9 @@ import type {
  * - `clone: false`              — no working-tree path (cloneRepo throws).
  * - `stateComment: 'postgres-only'` — adapter is inert; Postgres canonical.
  * - `approvalEvent: 'codecommit'`   — `UpdatePullRequestApprovalState` is
- *   the eventual target (gated by `codecommit.approvalState`; #74).
+ *   the supported target. Whether the adapter actually calls it on a
+ *   given review is gated by the runtime opt-in
+ *   `CodeCommitVCSOptions.approvalState: 'managed' | 'off'` (issue #74).
  *   `approvalEvent` advertises mapping availability, not opt-in state.
  * - `commitMessages: false`      — no per-PR commit-listing API; the
  *   adapter returns `pr.commitMessages = []`.
@@ -84,24 +87,54 @@ function mapDiffStatus(changeType: string | undefined): DiffFile['status'] {
 
 export type CodeCommitClientLike = Pick<CodeCommitClient, 'send'>;
 
+/**
+ * Operator opt-in for mapping `review.event` to CodeCommit's
+ * `UpdatePullRequestApprovalState` API (issue #74). The capability is
+ * advertised statically via {@link CODECOMMIT_CAPABILITIES.approvalEvent}
+ * (`'codecommit'`) regardless of this flag — the flag only gates whether
+ * the adapter actually issues the API call at `postReview` time.
+ *
+ * - `'off'` (default) — preserve the v0.2 behavior: `review.event` is
+ *   ignored and no approval-state call is made. Operators without an
+ *   approval rule applicable to the agent's IAM principal see no change.
+ * - `'managed'`       — translate `review.event` as follows:
+ *     - `APPROVE`         → `UpdatePullRequestApprovalState(APPROVE)`
+ *     - `REQUEST_CHANGES` → `UpdatePullRequestApprovalState(REVOKE)`
+ *     - `COMMENT`         → no-op (no approval-state call)
+ *   When the SDK call fails (e.g. no approval rule targets the agent),
+ *   the failure is logged via `console.warn` and the rest of `postReview`
+ *   proceeds.
+ */
+export type CodecommitApprovalState = 'managed' | 'off';
+
 export type CodeCommitVCSOptions = {
   /** Override the SDK client. Defaults to a client built from env / SDK chain. */
   readonly client?: CodeCommitClientLike;
   /** Optional client config when not supplying a custom `client`. */
   readonly clientConfig?: CodeCommitClientConfig;
+  /**
+   * Opt-in mapping of `review.event` to `UpdatePullRequestApprovalState`.
+   * See {@link CodecommitApprovalState}. Defaults to `'off'` for
+   * backward compatibility.
+   */
+  readonly approvalState?: CodecommitApprovalState;
 };
 
 export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
   const client =
     opts.client ?? (new CodeCommitClient(opts.clientConfig ?? {}) as CodeCommitClientLike);
+  const approvalStateMode: CodecommitApprovalState = opts.approvalState ?? 'off';
 
-  const getPR = async (ref: PRRef): Promise<PR> => {
-    ensureCodeCommit(ref);
+  const fetchCodeCommitPR = async (ref: PRRef): Promise<PullRequest> => {
     const out = await client.send(
       new GetPullRequestCommand({ pullRequestId: toPullRequestId(ref) }),
     );
     const pr: PullRequest | undefined = out.pullRequest;
     if (!pr) throw new Error(`PR ${ref.number} not found in CodeCommit repo ${ref.repo}`);
+    return pr;
+  };
+
+  const toPR = (ref: PRRef, pr: PullRequest): PR => {
     const target = pr.pullRequestTargets?.[0];
     return {
       ref,
@@ -124,6 +157,12 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
       createdAt: pr.creationDate?.toISOString() ?? new Date(0).toISOString(),
       updatedAt: pr.lastActivityDate?.toISOString() ?? new Date(0).toISOString(),
     };
+  };
+
+  const getPR = async (ref: PRRef): Promise<PR> => {
+    ensureCodeCommit(ref);
+    const pr = await fetchCodeCommitPR(ref);
+    return toPR(ref, pr);
   };
 
   const getDiff = async (ref: PRRef, deltaOpts: GetDiffOpts = {}): Promise<Diff> => {
@@ -174,12 +213,13 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
 
   const postReview = async (ref: PRRef, review: ReviewPayload): Promise<void> => {
     ensureCodeCommit(ref);
-    // `review.event` is honored by the GitHub adapter to drive
-    // `REQUEST_CHANGES`; CodeCommit has no equivalent merge-blocking
-    // review state on the comment API, so we intentionally drop it
-    // here. Operators wanting merge-blocking on CodeCommit must wire
-    // it via approval rules in CodeCommit itself.
-    const pr = await getPR(ref);
+    // Fetch the raw SDK PullRequest once so we have both the
+    // base/head commits (for comment posting) and the `revisionId`
+    // required by `UpdatePullRequestApprovalState` (#74). The mapping
+    // is gated behind the `approvalState: 'managed'` opt-in below;
+    // see the option doc on `CodeCommitVCSOptions.approvalState`.
+    const rawPr = await fetchCodeCommitPR(ref);
+    const pr = toPR(ref, rawPr);
     if (review.summary) {
       await client.send(
         new PostCommentForPullRequestCommand({
@@ -205,6 +245,51 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
           },
           content: c.body,
         }),
+      );
+    }
+    await applyApprovalState(ref, rawPr, review);
+  };
+
+  const applyApprovalState = async (
+    ref: PRRef,
+    rawPr: PullRequest,
+    review: ReviewPayload,
+  ): Promise<void> => {
+    if (approvalStateMode !== 'managed') return;
+    const event = review.event;
+    if (event !== 'APPROVE' && event !== 'REQUEST_CHANGES') return;
+    const revisionId = rawPr.revisionId;
+    if (!revisionId) {
+      // biome-ignore lint/suspicious/noConsole: operator-visible degrade-non-fatal log line
+      console.warn(
+        `[platform-codecommit] skipping UpdatePullRequestApprovalState for PR ${ref.number}: ` +
+          'no revisionId on PullRequest payload',
+      );
+      return;
+    }
+    const desired: 'APPROVE' | 'REVOKE' = event === 'APPROVE' ? 'APPROVE' : 'REVOKE';
+    try {
+      await client.send(
+        new UpdatePullRequestApprovalStateCommand({
+          pullRequestId: toPullRequestId(ref),
+          revisionId,
+          approvalState: desired,
+        }),
+      );
+    } catch (err) {
+      // Operators without an approval rule applicable to the agent's
+      // IAM principal will get a typed SDK error here
+      // (`ApprovalRuleDoesNotExistException`, `InvalidApprovalStateException`,
+      // etc.). Degrade non-fatally — the inline comments above were
+      // posted successfully, and the operator may not have wired an
+      // approval rule yet. Surface the error name so it shows up in
+      // logs without leaking the request payload.
+      const name = err instanceof Error ? err.name : 'UnknownError';
+      const message = err instanceof Error ? err.message : String(err);
+      // biome-ignore lint/suspicious/noConsole: operator-visible degrade-non-fatal log line
+      console.warn(
+        `[platform-codecommit] UpdatePullRequestApprovalState failed for PR ${ref.number} ` +
+          `(approvalState=${desired}): ${name}: ${message}`,
       );
     }
   };

--- a/packages/platform-codecommit/src/adapter.ts
+++ b/packages/platform-codecommit/src/adapter.ts
@@ -282,14 +282,22 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
       // (`ApprovalRuleDoesNotExistException`, `InvalidApprovalStateException`,
       // etc.). Degrade non-fatally — the inline comments above were
       // posted successfully, and the operator may not have wired an
-      // approval rule yet. Surface the error name so it shows up in
-      // logs without leaking the request payload.
-      const name = err instanceof Error ? err.name : 'UnknownError';
-      const message = err instanceof Error ? err.message : String(err);
+      // approval rule yet.
+      //
+      // Log ONLY the SDK error class name. AWS SDK error `message`
+      // strings frequently include the caller's role ARN and account
+      // id (e.g. `User: arn:aws:sts::123456789012:assumed-role/X is
+      // not authorized…`). Including `err.message` would leak that
+      // tenancy info into whatever sink stdout flows to. The error
+      // name alone is sufficient for operators to diagnose
+      // (`ApprovalRuleDoesNotExistException`, `AccessDeniedException`,
+      // …) without revealing IAM identity.
+      const name = err instanceof Error ? err.name : 'unknown';
       // biome-ignore lint/suspicious/noConsole: operator-visible degrade-non-fatal log line
       console.warn(
-        `[platform-codecommit] UpdatePullRequestApprovalState failed for PR ${ref.number} ` +
-          `(approvalState=${desired}): ${name}: ${message}`,
+        `[platform-codecommit] UpdatePullRequestApprovalState failed (${name}); ` +
+          `the agent's IAM principal may have no applicable approval rule. ` +
+          `Skipped approval-state mutation for PR ${toPullRequestId(ref)}.`,
       );
     }
   };

--- a/packages/platform-codecommit/src/iam-drift.test.ts
+++ b/packages/platform-codecommit/src/iam-drift.test.ts
@@ -7,6 +7,8 @@ import { EXPECTED_COMMANDS, EXPECTED_PERMISSIONS, PENDING_COMMANDS } from './iam
 const here = dirname(fileURLToPath(import.meta.url));
 const ADAPTER_PATH = resolve(here, 'adapter.ts');
 const README_PATH = resolve(here, '..', 'README.md');
+// Repo root: packages/platform-codecommit/src → repo root is three levels up.
+const SPEC_PATH = resolve(here, '..', '..', '..', 'docs', 'specs', 'review-agent-spec.md');
 
 /**
  * Extract every `new <X>Command(` occurrence from the adapter source.
@@ -99,6 +101,31 @@ describe('IAM ↔ SDK Command drift', () => {
       missing,
       `permissions present in EXPECTED_PERMISSIONS but missing from README IAM block — ` +
         `update packages/platform-codecommit/README.md: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every EXPECTED_PERMISSIONS entry appears inside spec §8.4', () => {
+    // Issue #78 framed this drift test as a "spec ↔ code drift
+    // detector". Without this assertion the spec can silently fall
+    // out of sync with the registry (as it did pre-audit when
+    // `codecommit:GetCommentsForPullRequest` was omitted from §8.4).
+    const spec = readFileSync(SPEC_PATH, 'utf8');
+    const sectionStart = spec.indexOf('### 8.4 CodeCommit');
+    expect(sectionStart, 'spec §8.4 CodeCommit heading not found').toBeGreaterThan(-1);
+    // Find the next "### " heading after §8.4 to bound the slice.
+    const afterHeading = spec.indexOf('\n', sectionStart) + 1;
+    const nextHeadingRel = spec.slice(afterHeading).search(/\n### /);
+    const sectionEnd = nextHeadingRel === -1 ? spec.length : afterHeading + nextHeadingRel;
+    const section = spec.slice(sectionStart, sectionEnd);
+
+    const missing: string[] = [];
+    for (const permission of EXPECTED_PERMISSIONS) {
+      if (!section.includes(permission)) missing.push(permission);
+    }
+    expect(
+      missing,
+      `permissions present in EXPECTED_PERMISSIONS but missing from spec §8.4 — ` +
+        `update docs/specs/review-agent-spec.md: ${missing.join(', ')}`,
     ).toEqual([]);
   });
 

--- a/packages/platform-codecommit/src/iam-drift.test.ts
+++ b/packages/platform-codecommit/src/iam-drift.test.ts
@@ -102,12 +102,12 @@ describe('IAM ↔ SDK Command drift', () => {
     ).toEqual([]);
   });
 
-  it('UpdatePullRequestApprovalStateCommand is registered ahead of issue #74', () => {
-    // #74 will wire `UpdatePullRequestApprovalStateCommand` into
-    // adapter.ts. The registry lists it now so the IAM block does not
-    // lag the planned surface. Once #74 lands the Command will also
-    // appear in `adapterCommands`; either way this assertion holds
-    // because it only checks the registry side.
+  it('UpdatePullRequestApprovalStateCommand is registered and wired (post issue #74)', () => {
+    // Issue #74 wired `UpdatePullRequestApprovalStateCommand` into
+    // adapter.ts, so the Command must appear in both the registry and
+    // the adapter usage set. It is no longer in PENDING_COMMANDS.
     expect(registryCommands.has('UpdatePullRequestApprovalStateCommand')).toBe(true);
+    expect(adapterCommands.has('UpdatePullRequestApprovalStateCommand')).toBe(true);
+    expect(PENDING_COMMANDS.has('UpdatePullRequestApprovalStateCommand')).toBe(false);
   });
 });

--- a/packages/platform-codecommit/src/iam-drift.test.ts
+++ b/packages/platform-codecommit/src/iam-drift.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { EXPECTED_COMMANDS, EXPECTED_PERMISSIONS, PENDING_COMMANDS } from './iam.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ADAPTER_PATH = resolve(here, 'adapter.ts');
+const README_PATH = resolve(here, '..', 'README.md');
+
+/**
+ * Extract every `new <X>Command(` occurrence from the adapter source.
+ * `adapter.ts` does not build Command instances dynamically, so a regex
+ * is sufficient — a full AST traversal would not catch any additional
+ * cases that this regex misses.
+ */
+function extractCommandsFromAdapter(): ReadonlySet<string> {
+  const src = readFileSync(ADAPTER_PATH, 'utf8');
+  const found = new Set<string>();
+  const re = /new\s+(\w+Command)\s*\(/g;
+  for (const match of src.matchAll(re)) {
+    const name = match[1];
+    if (name) found.add(name);
+  }
+  return found;
+}
+
+describe('IAM ↔ SDK Command drift', () => {
+  const adapterCommands = extractCommandsFromAdapter();
+  const registryCommands = new Set(EXPECTED_COMMANDS.map((pair) => pair.command));
+
+  it('extracts at least one Command from adapter.ts (regex sanity)', () => {
+    // Defensive: if the regex returned an empty set, the rest of the
+    // assertions would pass vacuously. Fail loudly instead.
+    expect(adapterCommands.size).toBeGreaterThan(0);
+  });
+
+  it('every Command used in adapter.ts has a registry entry', () => {
+    const missing: string[] = [];
+    for (const name of adapterCommands) {
+      if (!registryCommands.has(name)) missing.push(name);
+    }
+    expect(
+      missing,
+      `adapter.ts uses Command(s) not listed in EXPECTED_COMMANDS — ` +
+        `add them to src/iam.ts and the IAM block in spec §8.4 / README.md: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every non-pending registry entry is referenced from adapter.ts', () => {
+    // The inverse direction: catches dead entries that bloat the IAM
+    // block. Commands listed in `PENDING_COMMANDS` are intentionally
+    // ahead of the code (docs lead implementation) and are excluded.
+    const unused: string[] = [];
+    for (const { command } of EXPECTED_COMMANDS) {
+      if (PENDING_COMMANDS.has(command)) continue;
+      if (!adapterCommands.has(command)) unused.push(command);
+    }
+    expect(
+      unused,
+      `EXPECTED_COMMANDS contains entries that adapter.ts no longer uses — ` +
+        `remove them from src/iam.ts or move them to PENDING_COMMANDS: ${unused.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every registry entry has a *Command-suffixed class name', () => {
+    const malformed = EXPECTED_COMMANDS.filter((pair) => !pair.command.endsWith('Command'));
+    expect(
+      malformed,
+      `EXPECTED_COMMANDS entries must reference SDK class names ending in "Command": ` +
+        `${malformed.map((p) => p.command).join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every registry entry has a codecommit:-prefixed permission', () => {
+    const malformed = EXPECTED_COMMANDS.filter(
+      (pair) => !pair.permission.startsWith('codecommit:'),
+    );
+    expect(
+      malformed,
+      `EXPECTED_COMMANDS permission strings must start with "codecommit:": ` +
+        `${malformed.map((p) => p.permission).join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every EXPECTED_PERMISSIONS entry is mentioned inside the README IAM block', () => {
+    const readme = readFileSync(README_PATH, 'utf8');
+    // Narrow to the IAM JSON fenced block so a stray match elsewhere in
+    // the README (e.g. an example) does not lull us into a false pass.
+    const iamMatch = readme.match(/```json\s*([\s\S]*?)```/);
+    expect(iamMatch, 'README.md must contain a ```json fenced IAM block').not.toBeNull();
+    const iamBlock = iamMatch?.[1] ?? '';
+
+    const missing: string[] = [];
+    for (const permission of EXPECTED_PERMISSIONS) {
+      if (!iamBlock.includes(permission)) missing.push(permission);
+    }
+    expect(
+      missing,
+      `permissions present in EXPECTED_PERMISSIONS but missing from README IAM block — ` +
+        `update packages/platform-codecommit/README.md: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('UpdatePullRequestApprovalStateCommand is registered ahead of issue #74', () => {
+    // #74 will wire `UpdatePullRequestApprovalStateCommand` into
+    // adapter.ts. The registry lists it now so the IAM block does not
+    // lag the planned surface. Once #74 lands the Command will also
+    // appear in `adapterCommands`; either way this assertion holds
+    // because it only checks the registry side.
+    expect(registryCommands.has('UpdatePullRequestApprovalStateCommand')).toBe(true);
+  });
+});

--- a/packages/platform-codecommit/src/iam.ts
+++ b/packages/platform-codecommit/src/iam.ts
@@ -21,9 +21,9 @@
  *   3. Re-run `pnpm --filter @review-agent/platform-codecommit test`.
  *
  * Some entries below correspond to Commands that are listed in the IAM
- * block but not yet exercised in `adapter.ts` (e.g. `PostCommentReply`,
- * and — until issue #74 lands — `UpdatePullRequestApprovalState`). They
- * remain in the registry so docs and ops never lag the planned surface.
+ * block but not yet exercised in `adapter.ts` (e.g. `PostCommentReply`).
+ * They remain in the registry so docs and ops never lag the planned
+ * surface.
  */
 
 export type ExpectedCommandPair = {
@@ -67,7 +67,4 @@ export const EXPECTED_PERMISSIONS: ReadonlySet<string> = new Set(
 export const PENDING_COMMANDS: ReadonlySet<string> = new Set([
   // Used by reply-on-comment flows (spec §10.3); not wired yet.
   'PostCommentReplyCommand',
-  // Issue #74 will wire this; we list it here so the IAM block stays
-  // ahead of the code rather than behind.
-  'UpdatePullRequestApprovalStateCommand',
 ]);

--- a/packages/platform-codecommit/src/iam.ts
+++ b/packages/platform-codecommit/src/iam.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry of `{ AWS SDK Command class, codecommit:* IAM permission }` pairs
+ * for the CodeCommit adapter. Source of truth: spec §8.4 + the IAM block in
+ * `packages/platform-codecommit/README.md`.
+ *
+ * Why this file exists:
+ *
+ * The CodeCommit adapter calls `client.send(new <X>Command(...))` for each
+ * AWS API it relies on. Each Command requires a corresponding `codecommit:*`
+ * action on the worker's IAM role. If a new `*Command` is added to
+ * `adapter.ts` without updating spec §8.4 / README, operators hit
+ * `AccessDenied` errors that are painful to diagnose. The companion
+ * `iam-drift.test.ts` enforces parity between this registry, the adapter
+ * source, and the README IAM block.
+ *
+ * When you add a new SDK Command to the adapter:
+ *   1. Append a `{ command, permission }` pair here.
+ *   2. Add the matching `codecommit:<Action>` line to:
+ *      - spec §8.4 (`docs/specs/review-agent-spec.md`)
+ *      - the IAM JSON block in `packages/platform-codecommit/README.md`
+ *   3. Re-run `pnpm --filter @review-agent/platform-codecommit test`.
+ *
+ * Some entries below correspond to Commands that are listed in the IAM
+ * block but not yet exercised in `adapter.ts` (e.g. `PostCommentReply`,
+ * and — until issue #74 lands — `UpdatePullRequestApprovalState`). They
+ * remain in the registry so docs and ops never lag the planned surface.
+ */
+
+export type ExpectedCommandPair = {
+  readonly command: string;
+  readonly permission: string;
+};
+
+export const EXPECTED_COMMANDS = [
+  { command: 'GetPullRequestCommand', permission: 'codecommit:GetPullRequest' },
+  { command: 'GetDifferencesCommand', permission: 'codecommit:GetDifferences' },
+  { command: 'GetFileCommand', permission: 'codecommit:GetFile' },
+  {
+    command: 'GetCommentsForPullRequestCommand',
+    permission: 'codecommit:GetCommentsForPullRequest',
+  },
+  {
+    command: 'PostCommentForPullRequestCommand',
+    permission: 'codecommit:PostCommentForPullRequest',
+  },
+  { command: 'PostCommentReplyCommand', permission: 'codecommit:PostCommentReply' },
+  {
+    command: 'UpdatePullRequestApprovalStateCommand',
+    permission: 'codecommit:UpdatePullRequestApprovalState',
+  },
+] as const satisfies ReadonlyArray<ExpectedCommandPair>;
+
+/**
+ * The set of `codecommit:*` action strings the worker's IAM role must
+ * grant. Derived from `EXPECTED_COMMANDS` so the two never drift.
+ */
+export const EXPECTED_PERMISSIONS: ReadonlySet<string> = new Set(
+  EXPECTED_COMMANDS.map((pair) => pair.permission),
+);
+
+/**
+ * Commands that the registry intentionally lists ahead of adapter usage.
+ * They appear in the IAM block (spec / README) but are not yet wired in
+ * `adapter.ts`. The drift test treats these as expected-but-unused so
+ * "Command in registry without code reference" does not false-positive.
+ */
+export const PENDING_COMMANDS: ReadonlySet<string> = new Set([
+  // Used by reply-on-comment flows (spec §10.3); not wired yet.
+  'PostCommentReplyCommand',
+  // Issue #74 will wire this; we list it here so the IAM block stays
+  // ahead of the code rather than behind.
+  'UpdatePullRequestApprovalStateCommand',
+]);

--- a/packages/platform-codecommit/src/index.ts
+++ b/packages/platform-codecommit/src/index.ts
@@ -1,5 +1,10 @@
 export {
+  CODECOMMIT_CAPABILITIES,
   type CodeCommitClientLike,
   type CodeCommitVCSOptions,
   createCodecommitVCS,
 } from './adapter.js';
+export {
+  CODECOMMIT_PLATFORM_ID,
+  codecommitPlatform,
+} from './platform.js';

--- a/packages/platform-codecommit/src/platform.test.ts
+++ b/packages/platform-codecommit/src/platform.test.ts
@@ -1,0 +1,68 @@
+import { _resetPlatformRegistryForTests, getPlatform, registerPlatform } from '@review-agent/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CODECOMMIT_PLATFORM_ID, codecommitPlatform } from './platform.js';
+
+describe('codecommitPlatform — parseRef', () => {
+  it('parses a bare "<repo>#<number>" ref', () => {
+    const ref = codecommitPlatform.parseRef('demo-repo#42');
+    expect(ref).toEqual({
+      platform: 'codecommit',
+      owner: '',
+      repo: 'demo-repo',
+      number: 42,
+    });
+  });
+
+  it('parses an ARN-style ref by taking the trailing repo segment', () => {
+    const ref = codecommitPlatform.parseRef(
+      'arn:aws:codecommit:us-east-1:123456789012:demo-repo#7',
+    );
+    expect(ref).toEqual({
+      platform: 'codecommit',
+      owner: '',
+      repo: 'demo-repo',
+      number: 7,
+    });
+  });
+
+  it('rejects refs without "#"', () => {
+    expect(() => codecommitPlatform.parseRef('demo-repo')).toThrow(/expected '<repo>#<number>'/);
+  });
+
+  it('rejects refs with a non-numeric PR id', () => {
+    expect(() => codecommitPlatform.parseRef('demo-repo#abc')).toThrow(
+      /Invalid CodeCommit PR number/,
+    );
+  });
+
+  it('rejects refs with PR number <= 0', () => {
+    expect(() => codecommitPlatform.parseRef('demo-repo#0')).toThrow(
+      /Invalid CodeCommit PR number/,
+    );
+  });
+
+  it('rejects refs with an empty repo segment', () => {
+    expect(() => codecommitPlatform.parseRef('#42')).toThrow(/expected '<repo>#<number>'/);
+  });
+});
+
+describe('codecommitPlatform — registry registration', () => {
+  beforeEach(() => {
+    _resetPlatformRegistryForTests();
+    registerPlatform(codecommitPlatform);
+  });
+  afterEach(() => {
+    _resetPlatformRegistryForTests();
+  });
+
+  it('resolves under id "codecommit"', () => {
+    expect(getPlatform(CODECOMMIT_PLATFORM_ID)).toBe(codecommitPlatform);
+  });
+
+  it('create() constructs a CodeCommit VCS with declared capabilities', () => {
+    const vcs = codecommitPlatform.create({});
+    expect(vcs.platform).toBe('codecommit');
+    expect(vcs.capabilities.clone).toBe(false);
+    expect(vcs.capabilities.stateComment).toBe('postgres-only');
+  });
+});

--- a/packages/platform-codecommit/src/platform.ts
+++ b/packages/platform-codecommit/src/platform.ts
@@ -1,0 +1,48 @@
+import {
+  type PlatformDefinition,
+  type PRRef,
+  platformId,
+  registerPlatform,
+} from '@review-agent/core';
+import { type CodeCommitVCSOptions, createCodecommitVCS } from './adapter.js';
+
+export const CODECOMMIT_PLATFORM_ID = platformId('codecommit');
+
+/**
+ * Parse a CodeCommit-style PR ref from a free-form descriptor.
+ *
+ * Accepted shapes (lossless for the CodeCommit case where there is no
+ * owner-level namespace and `pullRequestId` is an integer):
+ *
+ * - `'<repo>#<number>'`
+ * - `'arn:aws:codecommit:<region>:<account>:<repo>#<number>'`
+ *
+ * Returns a {@link PRRef} with `platform: 'codecommit'` and an empty
+ * `owner` (CodeCommit has no owner-level namespace; the adapter sets
+ * an empty string in its own ref shape too).
+ */
+function parseCodecommitRef(input: string): PRRef {
+  const idx = input.lastIndexOf('#');
+  if (idx < 1) {
+    throw new Error(`Invalid CodeCommit ref '${input}'; expected '<repo>#<number>'.`);
+  }
+  const left = input.slice(0, idx);
+  const right = input.slice(idx + 1);
+  const number = Number.parseInt(right, 10);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`Invalid CodeCommit PR number in ref '${input}'.`);
+  }
+  const repo = left.startsWith('arn:aws:codecommit:') ? (left.split(':').pop() ?? '') : left;
+  if (!repo) {
+    throw new Error(`Invalid CodeCommit repository name in ref '${input}'.`);
+  }
+  return { platform: 'codecommit', owner: '', repo, number };
+}
+
+export const codecommitPlatform: PlatformDefinition = {
+  id: CODECOMMIT_PLATFORM_ID,
+  parseRef: parseCodecommitRef,
+  create: (config: unknown) => createCodecommitVCS((config ?? {}) as CodeCommitVCSOptions),
+};
+
+registerPlatform(codecommitPlatform);

--- a/packages/platform-github/src/adapter.test.ts
+++ b/packages/platform-github/src/adapter.test.ts
@@ -55,6 +55,36 @@ describe('createGithubVCS', () => {
       commitMessages: true,
     });
   });
+
+  // SEC-5: defense-in-depth guard in `defaultCloneUrl`. JobMessageSchema's
+  // discriminated union already rejects github refs with empty owner at the
+  // queue boundary, but `cloneRepo` accepts a `PRRef` directly via the VCS
+  // interface (CLI, tests, future adapters). The adapter MUST refuse before
+  // interpolating the token into a malformed URL, and the thrown error MUST
+  // NOT contain the token (which would leak through log aggregators).
+  it('refuses to build a clone URL for a github ref with empty owner (no token in error)', async () => {
+    const token = 'ghs_super_secret_token_value';
+    const runGit = vi.fn(async () => undefined);
+    const vcs = createGithubVCS({
+      token,
+      octokit: createMockOctokit({}),
+      runGit,
+    });
+    const badRef = { platform: 'github', owner: '', repo: 'r', number: 9 } as const;
+    let caught: unknown;
+    try {
+      await vcs.cloneRepo(badRef, '/tmp/x', { depth: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/empty owner/);
+    expect(message).not.toContain(token);
+    expect(message).not.toContain('x-access-token');
+    // The guard runs before any git invocation.
+    expect(runGit).not.toHaveBeenCalled();
+  });
 });
 
 describe('getPR', () => {

--- a/packages/platform-github/src/adapter.test.ts
+++ b/packages/platform-github/src/adapter.test.ts
@@ -45,6 +45,16 @@ describe('createGithubVCS', () => {
     const vcs = createGithubVCS({ token: 't', octokit: createMockOctokit({}) });
     expect(vcs.platform).toBe('github');
   });
+
+  it('declares the full set of GitHub capabilities (clone, native state, github event, commit msgs)', () => {
+    const vcs = createGithubVCS({ token: 't', octokit: createMockOctokit({}) });
+    expect(vcs.capabilities).toEqual({
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    });
+  });
 });
 
 describe('getPR', () => {

--- a/packages/platform-github/src/adapter.ts
+++ b/packages/platform-github/src/adapter.ts
@@ -95,6 +95,19 @@ function ensureGithub(ref: PRRef): void {
 }
 
 function defaultCloneUrl(ref: PRRef, token: string): string {
+  // Defense-in-depth (SEC-5): the JobMessageSchema discriminated union
+  // already rejects github refs with an empty owner, but `PRRef` reaches
+  // this function via the VCS interface from callers that may have built
+  // the ref by hand (CLI, tests, future adapters). Refuse before
+  // interpolating the token — a `github.com//${repo}.git` URL is invalid
+  // and the resulting git error tends to echo back the URL, leaking the
+  // token. The error message MUST NOT include the token.
+  if (!ref.owner) {
+    throw new Error(`Refusing clone for github ref with empty owner: ${ref.repo}#${ref.number}`);
+  }
+  if (!ref.repo) {
+    throw new Error('Refusing clone for github ref with empty repo');
+  }
   return `https://x-access-token:${token}@github.com/${ref.owner}/${ref.repo}.git`;
 }
 

--- a/packages/platform-github/src/adapter.ts
+++ b/packages/platform-github/src/adapter.ts
@@ -11,7 +11,22 @@ import type {
   ReviewPayload,
   ReviewState,
   VCS,
+  VcsCapabilities,
 } from '@review-agent/core';
+
+/**
+ * Static capability declaration for GitHub — every flag is on. Kept
+ * here next to the adapter so the adapter and its capability claims
+ * stay in sync; deviations (e.g. a future GitHub Enterprise Server
+ * variant that drops a feature) should override at construction time.
+ */
+export const GITHUB_CAPABILITIES: VcsCapabilities = {
+  clone: true,
+  stateComment: 'native',
+  approvalEvent: 'github',
+  commitMessages: true,
+};
+
 import { cloneWithStrategy, defaultRunGit, type RunGit } from './clone.js';
 import { assertSafeRelativePath } from './path-guard.js';
 import {
@@ -341,6 +356,7 @@ export function createGithubVCS(opts: GithubVCSOptions): VCS {
 
   return {
     platform: 'github',
+    capabilities: GITHUB_CAPABILITIES,
     getPR,
     getDiff,
     getFile,

--- a/packages/platform-github/src/index.ts
+++ b/packages/platform-github/src/index.ts
@@ -1,4 +1,4 @@
-export { createGithubVCS, type GithubVCSOptions } from './adapter.js';
+export { createGithubVCS, GITHUB_CAPABILITIES, type GithubVCSOptions } from './adapter.js';
 export {
   type AppAuthClient,
   type AppAuthEnv,
@@ -23,6 +23,7 @@ export {
 } from './clone.js';
 export { createGithubOrgConfigFetch, type GithubOrgConfigDeps } from './org-config.js';
 export { assertSafeRelativePath } from './path-guard.js';
+export { GITHUB_PLATFORM_ID, githubPlatform } from './platform.js';
 export {
   buildSummaryWithState,
   formatStateComment,

--- a/packages/platform-github/src/platform.test.ts
+++ b/packages/platform-github/src/platform.test.ts
@@ -1,0 +1,72 @@
+import { _resetPlatformRegistryForTests, getPlatform, registerPlatform } from '@review-agent/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GITHUB_PLATFORM_ID, githubPlatform } from './platform.js';
+
+describe('githubPlatform — parseRef', () => {
+  it('parses an "owner/repo#number" ref', () => {
+    const ref = githubPlatform.parseRef('almondoo/review-agent#80');
+    expect(ref).toEqual({
+      platform: 'github',
+      owner: 'almondoo',
+      repo: 'review-agent',
+      number: 80,
+    });
+  });
+
+  it('rejects refs without "#"', () => {
+    expect(() => githubPlatform.parseRef('almondoo/review-agent')).toThrow(
+      /expected 'owner\/repo#number'/,
+    );
+  });
+
+  it('rejects refs missing "/"', () => {
+    expect(() => githubPlatform.parseRef('almondoo#80')).toThrow(/Invalid GitHub repo segment/);
+  });
+
+  it('rejects refs with an empty repo', () => {
+    expect(() => githubPlatform.parseRef('almondoo/#80')).toThrow(/Invalid GitHub repo segment/);
+  });
+
+  it('rejects refs with PR number <= 0', () => {
+    expect(() => githubPlatform.parseRef('almondoo/review-agent#0')).toThrow(
+      /Invalid GitHub PR number/,
+    );
+  });
+
+  it('rejects refs with non-numeric PR id', () => {
+    expect(() => githubPlatform.parseRef('almondoo/review-agent#abc')).toThrow(
+      /Invalid GitHub PR number/,
+    );
+  });
+});
+
+describe('githubPlatform — registry registration', () => {
+  beforeEach(() => {
+    _resetPlatformRegistryForTests();
+    registerPlatform(githubPlatform);
+  });
+  afterEach(() => {
+    _resetPlatformRegistryForTests();
+  });
+
+  it('resolves under id "github"', () => {
+    expect(getPlatform(GITHUB_PLATFORM_ID)).toBe(githubPlatform);
+  });
+
+  it('create() rejects missing config (no token)', () => {
+    expect(() => githubPlatform.create(undefined)).toThrow(
+      /githubPlatform.create requires a GithubVCSOptions/,
+    );
+  });
+
+  it('create() builds a GitHub VCS when given a token', () => {
+    const vcs = githubPlatform.create({ token: 'sample-token' });
+    expect(vcs.platform).toBe('github');
+    expect(vcs.capabilities).toEqual({
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    });
+  });
+});

--- a/packages/platform-github/src/platform.ts
+++ b/packages/platform-github/src/platform.ts
@@ -1,0 +1,49 @@
+import {
+  type PlatformDefinition,
+  type PRRef,
+  platformId,
+  registerPlatform,
+} from '@review-agent/core';
+import { createGithubVCS, type GithubVCSOptions } from './adapter.js';
+
+export const GITHUB_PLATFORM_ID = platformId('github');
+
+/**
+ * Parse a GitHub-style PR ref from `'owner/repo#number'`. Throws on
+ * malformed input; callers must catch.
+ */
+function parseGithubRef(input: string): PRRef {
+  const idx = input.lastIndexOf('#');
+  if (idx < 1) {
+    throw new Error(`Invalid GitHub ref '${input}'; expected 'owner/repo#number'.`);
+  }
+  const left = input.slice(0, idx);
+  const right = input.slice(idx + 1);
+  const slash = left.indexOf('/');
+  if (slash < 1 || slash === left.length - 1) {
+    throw new Error(`Invalid GitHub repo segment in ref '${input}'.`);
+  }
+  const number = Number.parseInt(right, 10);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`Invalid GitHub PR number in ref '${input}'.`);
+  }
+  return {
+    platform: 'github',
+    owner: left.slice(0, slash),
+    repo: left.slice(slash + 1),
+    number,
+  };
+}
+
+export const githubPlatform: PlatformDefinition = {
+  id: GITHUB_PLATFORM_ID,
+  parseRef: parseGithubRef,
+  create: (config: unknown) => {
+    if (!config || typeof config !== 'object') {
+      throw new Error('githubPlatform.create requires a GithubVCSOptions config object.');
+    }
+    return createGithubVCS(config as GithubVCSOptions);
+  },
+};
+
+registerPlatform(githubPlatform);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { createApp } from './app.js';
 
 const SECRET = 'sec';
+const TOPIC = 'arn:aws:sns:us-east-1:111111111111:t';
+const ACCOUNT = '111111111111';
 
 function makeDb() {
   const seen = new Set<string>();
@@ -26,6 +28,29 @@ function sign(body: string): string {
   return `sha256=${crypto.createHmac('sha256', SECRET).update(body).digest('hex')}`;
 }
 
+function snsBody(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    Type: 'Notification',
+    MessageId: 'sns-msg-1',
+    TopicArn: TOPIC,
+    Timestamp: '2026-04-30T00:00:00Z',
+    Signature: 'sig',
+    SignatureVersion: '2',
+    SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+    Message: JSON.stringify({
+      source: 'aws.codecommit',
+      account: ACCOUNT,
+      detail: {
+        event: 'pullRequestCreated',
+        pullRequestId: '1',
+        repositoryName: 'r',
+        sourceCommit: 'abc1234',
+      },
+    }),
+    ...overrides,
+  });
+}
+
 describe('createApp', () => {
   it('exposes /healthz', async () => {
     const app = createApp({
@@ -33,6 +58,7 @@ describe('createApp', () => {
       db: makeDb() as any,
       queue: { enqueue: vi.fn(), dequeue: vi.fn() },
       webhookSecret: SECRET,
+      allowedSnsTopicArns: [TOPIC],
     });
     const res = await app.request('/healthz');
     expect(res.status).toBe(200);
@@ -47,6 +73,7 @@ describe('createApp', () => {
       queue: { enqueue, dequeue: vi.fn() },
       webhookSecret: SECRET,
       now: () => new Date('2026-04-30T00:00:00Z'),
+      allowedSnsTopicArns: [TOPIC],
     });
     const body = JSON.stringify({
       action: 'opened',
@@ -76,6 +103,7 @@ describe('createApp', () => {
       db: makeDb() as any,
       queue: { enqueue: vi.fn(), dequeue: vi.fn() },
       webhookSecret: SECRET,
+      allowedSnsTopicArns: [TOPIC],
     });
     const res = await app.request('/webhook', {
       method: 'POST',
@@ -93,6 +121,7 @@ describe('createApp', () => {
       db: db as any,
       queue: { enqueue, dequeue: vi.fn() },
       webhookSecret: SECRET,
+      allowedSnsTopicArns: [TOPIC],
     });
     const body = JSON.stringify({ zen: 'ping', hook_id: 1 });
     const reqInit = {
@@ -110,5 +139,210 @@ describe('createApp', () => {
     const r2 = await app.request('/webhook', reqInit);
     expect(r2.status).toBe(200);
     expect(await r2.json()).toEqual({ deduped: true });
+  });
+
+  describe('SEC-1: /webhook/codecommit fail-closed on missing allowlist', () => {
+    it('rejects with 403 when no allowlist is configured', async () => {
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: makeDb() as any,
+        queue: { enqueue: vi.fn(), dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+      });
+      const res = await app.request('/webhook/codecommit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: snsBody(),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects with 403 when TopicArn is not on the allowlist', async () => {
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: makeDb() as any,
+        queue: { enqueue: vi.fn(), dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        allowedSnsTopicArns: ['arn:aws:sns:us-east-1:111111111111:other'],
+      });
+      const res = await app.request('/webhook/codecommit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: snsBody(),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects with 403 for off-allowlist SubscriptionConfirmation (control-bypass path)', async () => {
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: makeDb() as any,
+        queue: { enqueue: vi.fn(), dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        allowedSnsTopicArns: ['arn:aws:sns:us-east-1:111111111111:other'],
+      });
+      const sub = JSON.stringify({
+        Type: 'SubscriptionConfirmation',
+        MessageId: 'm-x',
+        TopicArn: TOPIC,
+        Timestamp: '2026-04-30T00:00:00Z',
+        Signature: 'sig',
+        SignatureVersion: '2',
+        SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=t',
+        Message: 'You have chosen to subscribe',
+      });
+      const res = await app.request('/webhook/codecommit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: sub,
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('reads REVIEW_AGENT_SNS_TOPIC_ARNS from env when allowedSnsTopicArns is not passed', async () => {
+      const prev = process.env.REVIEW_AGENT_SNS_TOPIC_ARNS;
+      process.env.REVIEW_AGENT_SNS_TOPIC_ARNS = `${TOPIC}, arn:aws:sns:us-east-1:111111111111:b`;
+      try {
+        const enqueue = vi.fn().mockResolvedValue({ messageId: 'm-cc' });
+        const app = createApp({
+          // biome-ignore lint/suspicious/noExplicitAny: mock
+          db: makeDb() as any,
+          queue: { enqueue, dequeue: vi.fn() },
+          webhookSecret: SECRET,
+          sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        });
+        const res = await app.request('/webhook/codecommit', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: snsBody(),
+        });
+        expect(res.status).toBe(200);
+        expect(enqueue).toHaveBeenCalledOnce();
+      } finally {
+        if (prev === undefined) delete process.env.REVIEW_AGENT_SNS_TOPIC_ARNS;
+        else process.env.REVIEW_AGENT_SNS_TOPIC_ARNS = prev;
+      }
+    });
+  });
+
+  describe('SEC-3: namespaced delivery ids', () => {
+    it('persists the SNS MessageId as sns:<id> in the dedup table', async () => {
+      const db = makeDb();
+      const enqueue = vi.fn().mockResolvedValue({ messageId: 'm-cc' });
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: db as any,
+        queue: { enqueue, dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        allowedSnsTopicArns: [TOPIC],
+      });
+      const res = await app.request('/webhook/codecommit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: snsBody({ MessageId: 'abc' }),
+      });
+      expect(res.status).toBe(200);
+      expect(db.seen.has('sns:abc')).toBe(true);
+      expect(db.seen.has('abc')).toBe(false);
+    });
+
+    it('does not collide between a GitHub delivery id and an identical SNS MessageId', async () => {
+      const db = makeDb();
+      const enqueue = vi.fn().mockResolvedValue({ messageId: 'm' });
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: db as any,
+        queue: { enqueue, dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        allowedSnsTopicArns: [TOPIC],
+      });
+      const ghBody = JSON.stringify({ zen: 'ping', hook_id: 1 });
+      const ghRes = await app.request('/webhook', {
+        method: 'POST',
+        headers: {
+          'x-hub-signature-256': sign(ghBody),
+          'x-github-event': 'ping',
+          'x-github-delivery': 'shared-uuid',
+          'content-type': 'application/json',
+        },
+        body: ghBody,
+      });
+      expect(ghRes.status).toBe(200);
+      // Same UUID for the SNS MessageId should *not* be deduped: the
+      // codecommit bridge writes `sns:shared-uuid`, not `shared-uuid`.
+      const snsRes = await app.request('/webhook/codecommit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: snsBody({ MessageId: 'shared-uuid' }),
+      });
+      expect(snsRes.status).toBe(200);
+      const json = (await snsRes.json()) as { kind: string };
+      expect(json.kind).toBe('enqueued');
+    });
+  });
+
+  describe('SEC-8: SubscriptionConfirmation bypasses idempotency', () => {
+    it('processes a re-delivered SubscriptionConfirmation a second time', async () => {
+      const db = makeDb();
+      const confirmFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      const app = createApp({
+        // biome-ignore lint/suspicious/noExplicitAny: mock
+        db: db as any,
+        queue: { enqueue: vi.fn(), dequeue: vi.fn() },
+        webhookSecret: SECRET,
+        sns: { fetchCert: async () => 'PEM', verifySignature: () => true },
+        allowedSnsTopicArns: [TOPIC],
+      });
+      // Pre-seed the dedup table with `sns:retry` so a subsequent
+      // Notification with that MessageId would dedup. SubscriptionConfirmation
+      // re-deliveries must *not* be affected — the operator needs every
+      // confirmation retry to actually run the confirm path.
+      db.seen.add('sns:retry');
+
+      // Patch global fetch so the handler's default SubscribeURL GET
+      // path is not exercised; we use the dep-injected
+      // `confirmFetch` only inside the handler.
+      const sub = JSON.stringify({
+        Type: 'SubscriptionConfirmation',
+        MessageId: 'retry',
+        TopicArn: TOPIC,
+        Timestamp: '2026-04-30T00:00:00Z',
+        Signature: 'sig',
+        SignatureVersion: '2',
+        SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+        Token: 'tok',
+        SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=tok',
+        Message: 'You have chosen to subscribe',
+      });
+      // Replace global fetch for the duration of the call so the
+      // handler's default SubscribeURL fetch is captured (we did not
+      // wire a dep override through createApp).
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = confirmFetch as unknown as typeof fetch;
+      try {
+        const r1 = await app.request('/webhook/codecommit', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: sub,
+        });
+        expect(r1.status).toBe(200);
+        const r2 = await app.request('/webhook/codecommit', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: sub,
+        });
+        expect(r2.status).toBe(200);
+        // Both calls must have hit the SubscribeURL — no silent dedup.
+        expect(confirmFetch).toHaveBeenCalledTimes(2);
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -11,6 +11,7 @@ import {
   type VerifySnsSignatureOpts,
   verifySnsSignature,
 } from './middleware/verify-sns-signature.js';
+import { namespaceDeliveryId } from './utils/namespace-delivery-id.js';
 
 export type AppDeps = {
   readonly db: DbClient;
@@ -23,6 +24,13 @@ export type AppDeps = {
    * leave these unset so the real `node:crypto` path runs.
    */
   readonly sns?: VerifySnsSignatureOpts;
+  /**
+   * SEC-1: allowlist of SNS Topic ARNs accepted by the CodeCommit
+   * endpoint. Empty / unset = reject every delivery (fail-closed). In
+   * production this is sourced from the `REVIEW_AGENT_SNS_TOPIC_ARNS`
+   * environment variable; tests inject the array directly.
+   */
+  readonly allowedSnsTopicArns?: ReadonlyArray<string>;
 };
 
 /**
@@ -30,15 +38,56 @@ export type AppDeps = {
  * pipeline) into the `x-github-delivery` header that the shared
  * `idempotency` middleware reads. This avoids forking the idempotency
  * middleware just for a different header name.
+ *
+ * SEC-3: prefix the value with `sns:` so an SNS MessageId UUID cannot
+ * probabilistically collide with a GitHub `X-GitHub-Delivery` UUID in
+ * the shared `webhook_deliveries.delivery_id` column. GitHub deliveries
+ * continue to write the bare value for back-compat with existing rows
+ * — the namespacing is one-sided by design, documented in
+ * `docs/deployment/aws.md` and `utils/namespace-delivery-id.ts`.
  */
 const snsMessageIdAsDeliveryId = createMiddleware<VerifySnsEnv>(async (c, next) => {
   const msg = c.get('snsMessage');
-  c.req.raw.headers.set('x-github-delivery', msg.MessageId);
+  c.req.raw.headers.set('x-github-delivery', namespaceDeliveryId('codecommit', msg.MessageId));
   await next();
 });
 
+/**
+ * SEC-8 (sub) / FUNC M-2: SNS may re-deliver `SubscriptionConfirmation`
+ * envelopes on retry. Without this short-circuit the second delivery
+ * is silently deduped by the idempotency middleware and the operator
+ * never sees the confirmation succeed. Subscription-control envelopes
+ * bypass `idempotency` entirely so every retry confirms (idempotent on
+ * the AWS side anyway — confirming an already-confirmed subscription
+ * is a no-op).
+ */
+function isSubscriptionControl(snsMessageType: string): boolean {
+  return (
+    snsMessageType === 'SubscriptionConfirmation' || snsMessageType === 'UnsubscribeConfirmation'
+  );
+}
+
+function resolveAllowedSnsTopicArns(opts: AppDeps): ReadonlyArray<string> {
+  if (opts.allowedSnsTopicArns !== undefined) return opts.allowedSnsTopicArns;
+  const env = typeof process !== 'undefined' ? process.env.REVIEW_AGENT_SNS_TOPIC_ARNS : undefined;
+  if (!env) return [];
+  return env
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 export function createApp(deps: AppDeps): Hono<VerifyEnv & VerifySnsEnv> {
   const app = new Hono<VerifyEnv & VerifySnsEnv>();
+
+  const allowedSnsTopicArns = resolveAllowedSnsTopicArns(deps);
+  if (allowedSnsTopicArns.length === 0) {
+    // One-shot warning at boot. The handler still rejects every
+    // delivery; this log line is the operator's hint about *why*.
+    process.stderr.write(
+      'review-agent: REVIEW_AGENT_SNS_TOPIC_ARNS is unset — /webhook/codecommit will reject every delivery (SEC-1 fail-closed)\n',
+    );
+  }
 
   app.get('/healthz', (c) => c.json({ ok: true }));
 
@@ -57,17 +106,42 @@ export function createApp(deps: AppDeps): Hono<VerifyEnv & VerifySnsEnv> {
     },
   );
 
+  // SEC-8 short-circuit middleware: skip idempotency for
+  // SubscriptionConfirmation / UnsubscribeConfirmation deliveries so
+  // SNS retries are not silently deduped.
+  const skipIdempotencyForControl = createMiddleware<VerifySnsEnv>(async (c, next) => {
+    const msg = c.get('snsMessage');
+    if (isSubscriptionControl(msg.Type)) {
+      // Bypass idempotency entirely; jump straight to the handler.
+      const result = await handleCodecommitWebhook(c, msg, {
+        queue: deps.queue,
+        allowedTopicArns: allowedSnsTopicArns,
+        ...(deps.now ? { now: deps.now } : {}),
+      });
+      if (result.kind === 'forbidden') {
+        return c.json({ error: 'forbidden', reason: result.reason }, 403);
+      }
+      return c.json(result, 200);
+    }
+    await next();
+  });
+
   app.post(
     '/webhook/codecommit',
     verifySnsSignature(deps.sns ?? {}),
+    skipIdempotencyForControl,
     snsMessageIdAsDeliveryId,
     idempotency({ db: deps.db }),
     async (c) => {
       const envelope = c.get('snsMessage');
       const result = await handleCodecommitWebhook(c, envelope, {
         queue: deps.queue,
+        allowedTopicArns: allowedSnsTopicArns,
         ...(deps.now ? { now: deps.now } : {}),
       });
+      if (result.kind === 'forbidden') {
+        return c.json({ error: 'forbidden', reason: result.reason }, 403);
+      }
       return c.json(result, 200);
     },
   );

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,19 +1,44 @@
 import type { QueueClient } from '@review-agent/core';
 import type { DbClient } from '@review-agent/db';
 import { Hono } from 'hono';
+import { createMiddleware } from 'hono/factory';
+import { handleCodecommitWebhook } from './handlers/codecommit-webhook.js';
 import { handleWebhook } from './handlers/webhook.js';
 import { idempotency } from './middleware/idempotency.js';
 import { type VerifyEnv, verifyGithubSignature } from './middleware/verify-signature.js';
+import {
+  type VerifySnsEnv,
+  type VerifySnsSignatureOpts,
+  verifySnsSignature,
+} from './middleware/verify-sns-signature.js';
 
 export type AppDeps = {
   readonly db: DbClient;
   readonly queue: QueueClient;
   readonly webhookSecret: string;
   readonly now?: () => Date;
+  /**
+   * SNS signature verification options. Tests inject `verifySignature`
+   * + `fetchCert` to keep the receiver offline. Production should
+   * leave these unset so the real `node:crypto` path runs.
+   */
+  readonly sns?: VerifySnsSignatureOpts;
 };
 
-export function createApp(deps: AppDeps): Hono<VerifyEnv> {
-  const app = new Hono<VerifyEnv>();
+/**
+ * Bridges the SNS `MessageId` (the dedup key for the CodeCommit
+ * pipeline) into the `x-github-delivery` header that the shared
+ * `idempotency` middleware reads. This avoids forking the idempotency
+ * middleware just for a different header name.
+ */
+const snsMessageIdAsDeliveryId = createMiddleware<VerifySnsEnv>(async (c, next) => {
+  const msg = c.get('snsMessage');
+  c.req.raw.headers.set('x-github-delivery', msg.MessageId);
+  await next();
+});
+
+export function createApp(deps: AppDeps): Hono<VerifyEnv & VerifySnsEnv> {
+  const app = new Hono<VerifyEnv & VerifySnsEnv>();
 
   app.get('/healthz', (c) => c.json({ ok: true }));
 
@@ -25,6 +50,21 @@ export function createApp(deps: AppDeps): Hono<VerifyEnv> {
       const event = c.req.header('x-github-event') ?? '';
       const body = c.get('parsedBody');
       const result = await handleWebhook(c, event as Parameters<typeof handleWebhook>[1], body, {
+        queue: deps.queue,
+        ...(deps.now ? { now: deps.now } : {}),
+      });
+      return c.json(result, 200);
+    },
+  );
+
+  app.post(
+    '/webhook/codecommit',
+    verifySnsSignature(deps.sns ?? {}),
+    snsMessageIdAsDeliveryId,
+    idempotency({ db: deps.db }),
+    async (c) => {
+      const envelope = c.get('snsMessage');
+      const result = await handleCodecommitWebhook(c, envelope, {
         queue: deps.queue,
         ...(deps.now ? { now: deps.now } : {}),
       });

--- a/packages/server/src/handlers/codecommit-webhook.test.ts
+++ b/packages/server/src/handlers/codecommit-webhook.test.ts
@@ -5,6 +5,10 @@ import { handleCodecommitWebhook } from './codecommit-webhook.js';
 
 const ctx = {} as unknown as Context;
 
+const TOPIC = 'arn:aws:sns:us-east-1:111111111111:t';
+const ACCOUNT = '111111111111';
+const allowedTopicArns = [TOPIC] as const;
+
 function makeQueue() {
   const enqueue = vi.fn().mockResolvedValue({ messageId: 'm-cc-1' });
   return {
@@ -17,7 +21,7 @@ function makeEnvelope(overrides: Partial<SnsMessage> = {}): SnsMessage {
   return {
     Type: 'Notification',
     MessageId: 'sns-msg-1',
-    TopicArn: 'arn:aws:sns:us-east-1:111111111111:t',
+    TopicArn: TOPIC,
     Timestamp: '2026-04-30T00:00:00Z',
     Signature: 'sig',
     SignatureVersion: '2',
@@ -27,12 +31,17 @@ function makeEnvelope(overrides: Partial<SnsMessage> = {}): SnsMessage {
   };
 }
 
-function eventBridgeMessage(detail: Record<string, unknown>): string {
-  return JSON.stringify({
+function eventBridgeMessage(
+  detail: Record<string, unknown>,
+  account: string | null = ACCOUNT,
+): string {
+  const envelope: Record<string, unknown> = {
     source: 'aws.codecommit',
     'detail-type': 'CodeCommit Pull Request State Change',
     detail,
-  });
+  };
+  if (account !== null) envelope.account = account;
+  return JSON.stringify(envelope);
 }
 
 describe('handleCodecommitWebhook', () => {
@@ -43,7 +52,11 @@ describe('handleCodecommitWebhook', () => {
       Type: 'SubscriptionConfirmation',
       SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=t',
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue, confirmFetch });
+    const r = await handleCodecommitWebhook(ctx, envelope, {
+      queue,
+      confirmFetch,
+      allowedTopicArns,
+    });
     expect(r).toEqual({ kind: 'subscription_confirmed' });
     expect(confirmFetch).toHaveBeenCalledWith(envelope.SubscribeURL);
     expect(enqueue).not.toHaveBeenCalled();
@@ -56,14 +69,18 @@ describe('handleCodecommitWebhook', () => {
       Type: 'SubscriptionConfirmation',
       SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription',
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue, confirmFetch });
+    const r = await handleCodecommitWebhook(ctx, envelope, {
+      queue,
+      confirmFetch,
+      allowedTopicArns,
+    });
     expect(r).toEqual({ kind: 'subscription_failed', status: 503 });
   });
 
   it('ignores SubscriptionConfirmation without SubscribeURL', async () => {
     const { queue } = makeQueue();
     const envelope = makeEnvelope({ Type: 'SubscriptionConfirmation' });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
   });
 
@@ -80,6 +97,7 @@ describe('handleCodecommitWebhook', () => {
     const r = await handleCodecommitWebhook(ctx, envelope, {
       queue,
       now: () => new Date('2026-04-30T00:00:00Z'),
+      allowedTopicArns,
     });
     expect(r).toEqual({ kind: 'enqueued', messageId: 'm-cc-1' });
     expect(enqueue).toHaveBeenCalledOnce();
@@ -92,7 +110,9 @@ describe('handleCodecommitWebhook', () => {
       number: 42,
       headSha: 'abc1234567',
     });
-    expect(call.installationId).toBe('sns-msg-1');
+    // FUNC C-1: installationId is the EventBridge account, not the
+    // per-delivery SNS MessageId.
+    expect(call.installationId).toBe(ACCOUNT);
   });
 
   it('enqueues pullRequestSourceBranchUpdated as pull_request.synchronize', async () => {
@@ -104,7 +124,7 @@ describe('handleCodecommitWebhook', () => {
         repositoryName: 'repo-b',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('enqueued');
     expect(enqueue.mock.calls[0]?.[0].triggeredBy).toBe('pull_request.synchronize');
   });
@@ -118,7 +138,7 @@ describe('handleCodecommitWebhook', () => {
         repositoryName: 'repo-c',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('enqueued');
     expect(enqueue.mock.calls[0]?.[0].triggeredBy).toBe('pull_request.synchronize');
   });
@@ -133,7 +153,7 @@ describe('handleCodecommitWebhook', () => {
         commentContent: 'thanks! @review-agent review',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('enqueued');
     const call = enqueue.mock.calls[0]?.[0];
     expect(call.triggeredBy).toBe('comment.command');
@@ -150,7 +170,7 @@ describe('handleCodecommitWebhook', () => {
         commentContent: '@review-agent help',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r).toEqual({ kind: 'noop', reason: "command 'help' not yet implemented" });
     expect(enqueue).not.toHaveBeenCalled();
   });
@@ -165,7 +185,7 @@ describe('handleCodecommitWebhook', () => {
         commentContent: 'looks good',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
     expect(enqueue).not.toHaveBeenCalled();
   });
@@ -173,7 +193,7 @@ describe('handleCodecommitWebhook', () => {
   it('ignores a Notification with malformed (non-JSON) Message body', async () => {
     const { queue, enqueue } = makeQueue();
     const envelope = makeEnvelope({ Message: 'not-json' });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
     expect(r).toMatchObject({ reason: expect.stringContaining('malformed') });
     expect(enqueue).not.toHaveBeenCalled();
@@ -182,7 +202,7 @@ describe('handleCodecommitWebhook', () => {
   it('ignores a Notification with an empty Message', async () => {
     const { queue } = makeQueue();
     const envelope = makeEnvelope({ Message: '' });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
   });
 
@@ -195,7 +215,7 @@ describe('handleCodecommitWebhook', () => {
         repositoryName: 'r',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
     expect(enqueue).not.toHaveBeenCalled();
   });
@@ -205,12 +225,12 @@ describe('handleCodecommitWebhook', () => {
     const envelope = makeEnvelope({
       Message: eventBridgeMessage({ event: 'pullRequestCreated' }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it('accepts a flat (non-EventBridge) Message payload', async () => {
+  it('rejects flat (non-EventBridge) Message payloads — missing account (FUNC C-1)', async () => {
     const { queue, enqueue } = makeQueue();
     const envelope = makeEnvelope({
       Message: JSON.stringify({
@@ -219,9 +239,10 @@ describe('handleCodecommitWebhook', () => {
         repositoryNames: ['repo-flat'],
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
-    expect(r.kind).toBe('enqueued');
-    expect(enqueue.mock.calls[0]?.[0].prRef.repo).toBe('repo-flat');
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
+    expect(r.kind).toBe('ignored');
+    expect(r).toMatchObject({ reason: expect.stringContaining('account') });
+    expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('rejects an invalid pullRequestId (non-numeric string)', async () => {
@@ -233,7 +254,7 @@ describe('handleCodecommitWebhook', () => {
         repositoryName: 'r',
       }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
     expect(enqueue).not.toHaveBeenCalled();
   });
@@ -241,9 +262,78 @@ describe('handleCodecommitWebhook', () => {
   it('rejects a non-string event field', async () => {
     const { queue } = makeQueue();
     const envelope = makeEnvelope({
-      Message: JSON.stringify({ detail: { event: 42, pullRequestId: '1', repositoryName: 'r' } }),
+      Message: JSON.stringify({
+        account: ACCOUNT,
+        detail: { event: 42, pullRequestId: '1', repositoryName: 'r' },
+      }),
     });
-    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
     expect(r.kind).toBe('ignored');
+  });
+
+  it('rejects a pullRequestId beyond Number.MAX_SAFE_INTEGER (FUNC M-1)', async () => {
+    const { queue, enqueue } = makeQueue();
+    // 2^53 + 1, the smallest positive integer that loses precision in
+    // IEEE-754 doubles. `Number.isInteger` returns true here, but
+    // `Number.isSafeInteger` correctly returns false.
+    const unsafe = '9007199254740993';
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestCreated',
+        pullRequestId: unsafe,
+        repositoryName: 'r',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
+    expect(r.kind).toBe('ignored');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  describe('SEC-1: TopicArn allowlist', () => {
+    it('rejects forbidden when the allowlist is empty (fail-closed)', async () => {
+      const { queue, enqueue } = makeQueue();
+      const envelope = makeEnvelope({
+        Message: eventBridgeMessage({
+          event: 'pullRequestCreated',
+          pullRequestId: '1',
+          repositoryName: 'r',
+        }),
+      });
+      const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+      expect(r.kind).toBe('forbidden');
+      expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects forbidden when the envelope TopicArn is not on the allowlist', async () => {
+      const { queue, enqueue } = makeQueue();
+      const envelope = makeEnvelope({
+        TopicArn: 'arn:aws:sns:us-east-1:999999999999:rogue',
+        Message: eventBridgeMessage({
+          event: 'pullRequestCreated',
+          pullRequestId: '1',
+          repositoryName: 'r',
+        }),
+      });
+      const r = await handleCodecommitWebhook(ctx, envelope, { queue, allowedTopicArns });
+      expect(r.kind).toBe('forbidden');
+      expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects forbidden for SubscriptionConfirmation off-allowlist (prevents takeover)', async () => {
+      const { queue } = makeQueue();
+      const confirmFetch = vi.fn();
+      const envelope = makeEnvelope({
+        Type: 'SubscriptionConfirmation',
+        TopicArn: 'arn:aws:sns:us-east-1:999999999999:rogue',
+        SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription',
+      });
+      const r = await handleCodecommitWebhook(ctx, envelope, {
+        queue,
+        confirmFetch,
+        allowedTopicArns,
+      });
+      expect(r.kind).toBe('forbidden');
+      expect(confirmFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/server/src/handlers/codecommit-webhook.test.ts
+++ b/packages/server/src/handlers/codecommit-webhook.test.ts
@@ -1,0 +1,249 @@
+import type { Context } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import type { SnsMessage } from '../middleware/verify-sns-signature.js';
+import { handleCodecommitWebhook } from './codecommit-webhook.js';
+
+const ctx = {} as unknown as Context;
+
+function makeQueue() {
+  const enqueue = vi.fn().mockResolvedValue({ messageId: 'm-cc-1' });
+  return {
+    queue: { enqueue, dequeue: vi.fn() },
+    enqueue,
+  };
+}
+
+function makeEnvelope(overrides: Partial<SnsMessage> = {}): SnsMessage {
+  return {
+    Type: 'Notification',
+    MessageId: 'sns-msg-1',
+    TopicArn: 'arn:aws:sns:us-east-1:111111111111:t',
+    Timestamp: '2026-04-30T00:00:00Z',
+    Signature: 'sig',
+    SignatureVersion: '2',
+    SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+    Message: '',
+    ...overrides,
+  };
+}
+
+function eventBridgeMessage(detail: Record<string, unknown>): string {
+  return JSON.stringify({
+    source: 'aws.codecommit',
+    'detail-type': 'CodeCommit Pull Request State Change',
+    detail,
+  });
+}
+
+describe('handleCodecommitWebhook', () => {
+  it('confirms an SNS SubscriptionConfirmation by GETting the SubscribeURL', async () => {
+    const { queue, enqueue } = makeQueue();
+    const confirmFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const envelope = makeEnvelope({
+      Type: 'SubscriptionConfirmation',
+      SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=t',
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, confirmFetch });
+    expect(r).toEqual({ kind: 'subscription_confirmed' });
+    expect(confirmFetch).toHaveBeenCalledWith(envelope.SubscribeURL);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('reports subscription_failed when SubscribeURL fetch returns non-2xx', async () => {
+    const { queue } = makeQueue();
+    const confirmFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const envelope = makeEnvelope({
+      Type: 'SubscriptionConfirmation',
+      SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription',
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue, confirmFetch });
+    expect(r).toEqual({ kind: 'subscription_failed', status: 503 });
+  });
+
+  it('ignores SubscriptionConfirmation without SubscribeURL', async () => {
+    const { queue } = makeQueue();
+    const envelope = makeEnvelope({ Type: 'SubscriptionConfirmation' });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+  });
+
+  it('enqueues pullRequestCreated as pull_request.opened', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestCreated',
+        pullRequestId: '42',
+        repositoryName: 'repo-a',
+        sourceCommit: 'abc1234567',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, {
+      queue,
+      now: () => new Date('2026-04-30T00:00:00Z'),
+    });
+    expect(r).toEqual({ kind: 'enqueued', messageId: 'm-cc-1' });
+    expect(enqueue).toHaveBeenCalledOnce();
+    const call = enqueue.mock.calls[0]?.[0];
+    expect(call.triggeredBy).toBe('pull_request.opened');
+    expect(call.prRef).toMatchObject({
+      platform: 'codecommit',
+      owner: '',
+      repo: 'repo-a',
+      number: 42,
+      headSha: 'abc1234567',
+    });
+    expect(call.installationId).toBe('sns-msg-1');
+  });
+
+  it('enqueues pullRequestSourceBranchUpdated as pull_request.synchronize', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestSourceBranchUpdated',
+        pullRequestId: 7,
+        repositoryName: 'repo-b',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('enqueued');
+    expect(enqueue.mock.calls[0]?.[0].triggeredBy).toBe('pull_request.synchronize');
+  });
+
+  it('accepts pullRequestSourceReferenceUpdated as a synchronize alias', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestSourceReferenceUpdated',
+        pullRequestId: '8',
+        repositoryName: 'repo-c',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('enqueued');
+    expect(enqueue.mock.calls[0]?.[0].triggeredBy).toBe('pull_request.synchronize');
+  });
+
+  it('enqueues commentOnPullRequest when comment contains @review-agent review', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'commentOnPullRequest',
+        pullRequestId: '9',
+        repositoryName: 'repo-d',
+        commentContent: 'thanks! @review-agent review',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('enqueued');
+    const call = enqueue.mock.calls[0]?.[0];
+    expect(call.triggeredBy).toBe('comment.command');
+    expect(call.prRef.number).toBe(9);
+  });
+
+  it('returns noop with "not yet implemented" for unsupported commands', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'commentOnPullRequest',
+        pullRequestId: '9',
+        repositoryName: 'repo-d',
+        commentContent: '@review-agent help',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r).toEqual({ kind: 'noop', reason: "command 'help' not yet implemented" });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores commentOnPullRequest without the @review-agent prefix', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'commentOnPullRequest',
+        pullRequestId: '9',
+        repositoryName: 'repo-d',
+        commentContent: 'looks good',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores a Notification with malformed (non-JSON) Message body', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({ Message: 'not-json' });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+    expect(r).toMatchObject({ reason: expect.stringContaining('malformed') });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores a Notification with an empty Message', async () => {
+    const { queue } = makeQueue();
+    const envelope = makeEnvelope({ Message: '' });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+  });
+
+  it('ignores an unhandled codecommit event type', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestMergeStatusUpdated',
+        pullRequestId: '1',
+        repositoryName: 'r',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores PR events missing repositoryName / pullRequestId', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({ event: 'pullRequestCreated' }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('accepts a flat (non-EventBridge) Message payload', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: JSON.stringify({
+        event: 'pullRequestCreated',
+        pullRequestId: '5',
+        repositoryNames: ['repo-flat'],
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('enqueued');
+    expect(enqueue.mock.calls[0]?.[0].prRef.repo).toBe('repo-flat');
+  });
+
+  it('rejects an invalid pullRequestId (non-numeric string)', async () => {
+    const { queue, enqueue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: eventBridgeMessage({
+        event: 'pullRequestCreated',
+        pullRequestId: 'not-a-number',
+        repositoryName: 'r',
+      }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string event field', async () => {
+    const { queue } = makeQueue();
+    const envelope = makeEnvelope({
+      Message: JSON.stringify({ detail: { event: 42, pullRequestId: '1', repositoryName: 'r' } }),
+    });
+    const r = await handleCodecommitWebhook(ctx, envelope, { queue });
+    expect(r.kind).toBe('ignored');
+  });
+});

--- a/packages/server/src/handlers/codecommit-webhook.ts
+++ b/packages/server/src/handlers/codecommit-webhook.ts
@@ -1,0 +1,207 @@
+import type { JobMessage, QueueClient } from '@review-agent/core';
+import type { Context } from 'hono';
+import type { SnsMessage } from '../middleware/verify-sns-signature.js';
+import { parseCommand } from '../utils/parse-command.js';
+
+export type CodecommitWebhookDeps = {
+  readonly queue: QueueClient;
+  readonly now?: () => Date;
+  /**
+   * Override `fetch` used to confirm an SNS `SubscriptionConfirmation`
+   * (`GET <SubscribeURL>`). Defaults to global `fetch`. Tests inject a
+   * stub to avoid network calls.
+   */
+  readonly confirmFetch?: (url: string) => Promise<{ ok: boolean; status: number }>;
+};
+
+export type CodecommitWebhookResult =
+  | { kind: 'subscription_confirmed' }
+  | { kind: 'subscription_failed'; status: number }
+  | { kind: 'enqueued'; messageId: string }
+  | { kind: 'noop'; reason: string }
+  | { kind: 'ignored'; reason: string };
+
+/**
+ * Shape of the CodeCommit event delivered inside the SNS envelope's
+ * `Message` field. Two common deliveries are supported:
+ *
+ * 1. **EventBridge envelope** (recommended): `aws.codecommit` → SNS
+ *    topic, with the entire EventBridge event JSON serialized into
+ *    `Message`. Fields of interest live under `detail.event` and
+ *    `detail.{pullRequestId, repositoryName, ...}`.
+ * 2. **CodeCommit-native SNS subscription**: CodeCommit can also publish
+ *    pull-request notifications directly to SNS, in which case the
+ *    flat fields land at the top of `Message`. We accept both.
+ */
+type CodecommitEvent = {
+  readonly event?: string;
+  readonly pullRequestId?: string | number;
+  readonly repositoryName?: string;
+  readonly repositoryNames?: ReadonlyArray<string>;
+  readonly sourceCommit?: string;
+  readonly destinationCommit?: string;
+  readonly commentId?: string;
+  readonly callerUserArn?: string;
+  readonly commentContent?: string;
+  readonly notificationBody?: string;
+};
+
+type EventBridgeEnvelope = {
+  readonly detail?: CodecommitEvent;
+  readonly source?: string;
+  readonly 'detail-type'?: string;
+};
+
+/**
+ * Maps a CodeCommit event type to a `JobMessage.triggeredBy` value, or
+ * `null` when the event does not warrant a review run. We mirror the
+ * GitHub mapping: opened / synchronize / comment.command.
+ */
+const PR_OPEN_EVENTS = new Set<string>(['pullRequestCreated']);
+const PR_SYNC_EVENTS = new Set<string>([
+  'pullRequestSourceBranchUpdated',
+  // CodeCommit also emits `pullRequestSourceReferenceUpdated` in some
+  // SDK versions; treat it the same.
+  'pullRequestSourceReferenceUpdated',
+]);
+
+/**
+ * Extract the inner CodeCommit event payload from the SNS `Message`
+ * string. Handles both delivery shapes (EventBridge wrapper or direct).
+ * Returns `null` on parse failure.
+ */
+function extractCodecommitEvent(snsMessage: string): CodecommitEvent | null {
+  try {
+    const parsed = JSON.parse(snsMessage) as EventBridgeEnvelope & CodecommitEvent;
+    if (parsed.detail && typeof parsed.detail === 'object') {
+      return parsed.detail;
+    }
+    if (typeof parsed === 'object' && parsed !== null) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function pickRepositoryName(ev: CodecommitEvent): string | null {
+  if (ev.repositoryName && ev.repositoryName.length > 0) return ev.repositoryName;
+  const first = ev.repositoryNames?.[0];
+  if (first && first.length > 0) return first;
+  return null;
+}
+
+function pickPrNumber(ev: CodecommitEvent): number | null {
+  if (ev.pullRequestId === undefined || ev.pullRequestId === null) return null;
+  const n =
+    typeof ev.pullRequestId === 'number' ? ev.pullRequestId : Number.parseInt(ev.pullRequestId, 10);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  return n;
+}
+
+/**
+ * Build the JobMessage for a CodeCommit PR.
+ *
+ * Note: `JobMessageSchema` in `core` currently pins
+ * `prRef.platform: z.literal('github')` — widening that schema to
+ * include `'codecommit'` belongs to a `core` change (out of scope for
+ * this handler-only PR). Since the GitHub adapter only consumes
+ * `platform: 'github'` jobs, the worker safely ignores any
+ * `'codecommit'` jobs that reach it until the schema is widened and a
+ * dispatcher routes by platform. The type assertion below is the
+ * narrowest possible workaround for the schema mismatch.
+ */
+function buildCodecommitJobMessage(
+  ev: CodecommitEvent,
+  triggeredBy: JobMessage['triggeredBy'],
+  now: Date,
+  snsMessageId: string,
+): JobMessage | null {
+  const repo = pickRepositoryName(ev);
+  const number = pickPrNumber(ev);
+  if (!repo || !number) return null;
+  const headSha = ev.sourceCommit;
+  // JobMessageSchema in core currently pins `prRef.platform: z.literal('github')`.
+  // Widening it to include `'codecommit'` is a separate core change; until then
+  // we mint the codecommit value here via an `unknown` round-trip so the
+  // receiver is ready as soon as the schema lifts, and no `any` is introduced.
+  const prRef = {
+    platform: 'codecommit',
+    owner: '',
+    repo,
+    number,
+    ...(headSha ? { headSha } : {}),
+  } as unknown as JobMessage['prRef'];
+  const msg: JobMessage = {
+    jobId: `codecommit:${repo}#${number}@${now.getTime()}`,
+    installationId: snsMessageId,
+    prRef,
+    triggeredBy,
+    enqueuedAt: now.toISOString(),
+  };
+  return msg;
+}
+
+export async function handleCodecommitWebhook(
+  _c: Context,
+  envelope: SnsMessage,
+  deps: CodecommitWebhookDeps,
+): Promise<CodecommitWebhookResult> {
+  const now = (deps.now ?? (() => new Date()))();
+
+  if (envelope.Type === 'SubscriptionConfirmation' || envelope.Type === 'UnsubscribeConfirmation') {
+    if (!envelope.SubscribeURL) {
+      return { kind: 'ignored', reason: 'missing SubscribeURL' };
+    }
+    const f =
+      deps.confirmFetch ??
+      (async (u: string) => {
+        const r = await fetch(u, { method: 'GET' });
+        return { ok: r.ok, status: r.status };
+      });
+    const res = await f(envelope.SubscribeURL);
+    if (!res.ok) {
+      return { kind: 'subscription_failed', status: res.status };
+    }
+    return { kind: 'subscription_confirmed' };
+  }
+
+  // Notification
+  if (!envelope.Message) {
+    return { kind: 'ignored', reason: 'missing SNS Message' };
+  }
+  const ev = extractCodecommitEvent(envelope.Message);
+  if (!ev || typeof ev.event !== 'string') {
+    return { kind: 'ignored', reason: 'malformed codecommit event' };
+  }
+
+  if (PR_OPEN_EVENTS.has(ev.event)) {
+    const msg = buildCodecommitJobMessage(ev, 'pull_request.opened', now, envelope.MessageId);
+    if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
+    const r = await deps.queue.enqueue(msg);
+    return { kind: 'enqueued', messageId: r.messageId };
+  }
+
+  if (PR_SYNC_EVENTS.has(ev.event)) {
+    const msg = buildCodecommitJobMessage(ev, 'pull_request.synchronize', now, envelope.MessageId);
+    if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
+    const r = await deps.queue.enqueue(msg);
+    return { kind: 'enqueued', messageId: r.messageId };
+  }
+
+  if (ev.event === 'commentOnPullRequest') {
+    const text = ev.commentContent ?? ev.notificationBody ?? '';
+    const command = parseCommand(text);
+    if (!command) return { kind: 'ignored', reason: 'no agent command' };
+    if (command !== 'review') {
+      return { kind: 'noop', reason: `command '${command}' not yet implemented` };
+    }
+    const msg = buildCodecommitJobMessage(ev, 'comment.command', now, envelope.MessageId);
+    if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
+    const r = await deps.queue.enqueue(msg);
+    return { kind: 'enqueued', messageId: r.messageId };
+  }
+
+  return { kind: 'ignored', reason: `unhandled codecommit event '${ev.event}'` };
+}

--- a/packages/server/src/handlers/codecommit-webhook.ts
+++ b/packages/server/src/handlers/codecommit-webhook.ts
@@ -12,6 +12,22 @@ export type CodecommitWebhookDeps = {
    * stub to avoid network calls.
    */
   readonly confirmFetch?: (url: string) => Promise<{ ok: boolean; status: number }>;
+  /**
+   * Allowlist of SNS Topic ARNs accepted by this receiver (SEC-1).
+   *
+   * The SNS message signature only proves "some AWS SNS topic in some
+   * account signed this envelope". Without a topic-level allowlist an
+   * attacker who owns an SNS topic in any AWS account could deliver
+   * a `SubscriptionConfirmation` to our endpoint, watch us confirm,
+   * and then deliver forged `commentOnPullRequest` notifications that
+   * pass signature verification.
+   *
+   * The receiver is fail-closed: an unset or empty allowlist rejects
+   * every delivery with `kind: 'forbidden'`. Operators must opt in
+   * explicitly via the `REVIEW_AGENT_SNS_TOPIC_ARNS` env (see
+   * `docs/deployment/aws.md`).
+   */
+  readonly allowedTopicArns?: ReadonlyArray<string>;
 };
 
 export type CodecommitWebhookResult =
@@ -19,7 +35,8 @@ export type CodecommitWebhookResult =
   | { kind: 'subscription_failed'; status: number }
   | { kind: 'enqueued'; messageId: string }
   | { kind: 'noop'; reason: string }
-  | { kind: 'ignored'; reason: string };
+  | { kind: 'ignored'; reason: string }
+  | { kind: 'forbidden'; reason: string };
 
 /**
  * Shape of the CodeCommit event delivered inside the SNS envelope's
@@ -50,6 +67,7 @@ type EventBridgeEnvelope = {
   readonly detail?: CodecommitEvent;
   readonly source?: string;
   readonly 'detail-type'?: string;
+  readonly account?: string;
 };
 
 /**
@@ -66,18 +84,22 @@ const PR_SYNC_EVENTS = new Set<string>([
 ]);
 
 /**
- * Extract the inner CodeCommit event payload from the SNS `Message`
- * string. Handles both delivery shapes (EventBridge wrapper or direct).
- * Returns `null` on parse failure.
+ * Extract the inner CodeCommit event payload + (when present) the
+ * EventBridge envelope's `account` field. The envelope's `account` is
+ * a 12-digit AWS account ID; we use it as a stable `installationId`
+ * (FUNC C-1 audit fix). Returns both pieces in one parse pass.
  */
-function extractCodecommitEvent(snsMessage: string): CodecommitEvent | null {
+function extractCodecommitEvent(
+  snsMessage: string,
+): { readonly event: CodecommitEvent; readonly account: string | null } | null {
   try {
     const parsed = JSON.parse(snsMessage) as EventBridgeEnvelope & CodecommitEvent;
     if (parsed.detail && typeof parsed.detail === 'object') {
-      return parsed.detail;
+      const account = typeof parsed.account === 'string' ? parsed.account : null;
+      return { event: parsed.detail, account };
     }
     if (typeof parsed === 'object' && parsed !== null) {
-      return parsed;
+      return { event: parsed, account: null };
     }
     return null;
   } catch {
@@ -96,22 +118,34 @@ function pickPrNumber(ev: CodecommitEvent): number | null {
   if (ev.pullRequestId === undefined || ev.pullRequestId === null) return null;
   const n =
     typeof ev.pullRequestId === 'number' ? ev.pullRequestId : Number.parseInt(ev.pullRequestId, 10);
-  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  // FUNC M-1: reject unsafe integers (>2^53). `Number.isSafeInteger`
+  // is the right guard — `Number.isInteger` accepts values that lose
+  // precision when round-tripped through `String()`.
+  if (!Number.isSafeInteger(n) || n <= 0) return null;
   return n;
 }
 
 /**
  * Build the JobMessage for a CodeCommit PR.
  *
- * `JobMessageSchema.prRef.platform` is now a `'github' | 'codecommit'`
- * enum (widened in core as the issue #73 follow-on), so we can build
- * the prRef as a plain typed object without any `unknown` cast.
+ * `installationId` is the EventBridge envelope's `account` field (a
+ * 12-digit AWS account ID). FUNC C-1 audit fix:
+ *
+ * - Stable across deliveries (was previously the per-delivery SNS
+ *   MessageId, which broke incremental-review keying).
+ * - Numeric, so it passes `withTenant`'s `/^\d+$/` guard in
+ *   `packages/db/src/tenancy.ts:27`.
+ * - Fits in the `bigint` columns the schema uses for installation_id.
+ *
+ * Multiple repositories in the same account share the installationId;
+ * per-PR keying via `review_state.id = ${owner}/${repo}#${number}`
+ * continues to differentiate them.
  */
 function buildCodecommitJobMessage(
   ev: CodecommitEvent,
   triggeredBy: JobMessage['triggeredBy'],
   now: Date,
-  snsMessageId: string,
+  installationId: string,
 ): JobMessage | null {
   const repo = pickRepositoryName(ev);
   const number = pickPrNumber(ev);
@@ -126,12 +160,24 @@ function buildCodecommitJobMessage(
   };
   const msg: JobMessage = {
     jobId: `codecommit:${repo}#${number}@${now.getTime()}`,
-    installationId: snsMessageId,
+    installationId,
     prRef,
     triggeredBy,
     enqueuedAt: now.toISOString(),
   };
   return msg;
+}
+
+/**
+ * SEC-1: validate the envelope's `TopicArn` against the allowlist.
+ *
+ * Fail-closed: empty/missing allowlist rejects everything. The operator
+ * must set `REVIEW_AGENT_SNS_TOPIC_ARNS` (or pass `allowedTopicArns`
+ * in tests) explicitly.
+ */
+function isAllowedTopic(envelope: SnsMessage, allowlist: ReadonlyArray<string>): boolean {
+  if (allowlist.length === 0) return false;
+  return allowlist.includes(envelope.TopicArn);
 }
 
 export async function handleCodecommitWebhook(
@@ -140,6 +186,19 @@ export async function handleCodecommitWebhook(
   deps: CodecommitWebhookDeps,
 ): Promise<CodecommitWebhookResult> {
   const now = (deps.now ?? (() => new Date()))();
+  const allowlist = deps.allowedTopicArns ?? [];
+
+  // SEC-1: gate every delivery — including SubscriptionConfirmation —
+  // on the TopicArn allowlist before doing anything else.
+  if (!isAllowedTopic(envelope, allowlist)) {
+    return {
+      kind: 'forbidden',
+      reason:
+        allowlist.length === 0
+          ? 'REVIEW_AGENT_SNS_TOPIC_ARNS is unset; the receiver is fail-closed by design'
+          : `TopicArn '${envelope.TopicArn}' is not in the configured allowlist`,
+    };
+  }
 
   if (envelope.Type === 'SubscriptionConfirmation' || envelope.Type === 'UnsubscribeConfirmation') {
     if (!envelope.SubscribeURL) {
@@ -162,20 +221,35 @@ export async function handleCodecommitWebhook(
   if (!envelope.Message) {
     return { kind: 'ignored', reason: 'missing SNS Message' };
   }
-  const ev = extractCodecommitEvent(envelope.Message);
-  if (!ev || typeof ev.event !== 'string') {
+  const extracted = extractCodecommitEvent(envelope.Message);
+  if (!extracted) {
+    return { kind: 'ignored', reason: 'malformed codecommit event' };
+  }
+  const ev = extracted.event;
+  if (typeof ev.event !== 'string') {
     return { kind: 'ignored', reason: 'malformed codecommit event' };
   }
 
+  // FUNC C-1: require a numeric AWS account ID to use as installationId.
+  // CodeCommit-native (flat) deliveries do not include `account`; the
+  // receiver requires the EventBridge wrapper for tenancy enforcement.
+  const installationId = extracted.account ?? null;
+  if (installationId === null || !/^\d+$/.test(installationId)) {
+    return {
+      kind: 'ignored',
+      reason: 'missing or non-numeric EventBridge account (required for installationId)',
+    };
+  }
+
   if (PR_OPEN_EVENTS.has(ev.event)) {
-    const msg = buildCodecommitJobMessage(ev, 'pull_request.opened', now, envelope.MessageId);
+    const msg = buildCodecommitJobMessage(ev, 'pull_request.opened', now, installationId);
     if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
     const r = await deps.queue.enqueue(msg);
     return { kind: 'enqueued', messageId: r.messageId };
   }
 
   if (PR_SYNC_EVENTS.has(ev.event)) {
-    const msg = buildCodecommitJobMessage(ev, 'pull_request.synchronize', now, envelope.MessageId);
+    const msg = buildCodecommitJobMessage(ev, 'pull_request.synchronize', now, installationId);
     if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
     const r = await deps.queue.enqueue(msg);
     return { kind: 'enqueued', messageId: r.messageId };
@@ -188,7 +262,7 @@ export async function handleCodecommitWebhook(
     if (command !== 'review') {
       return { kind: 'noop', reason: `command '${command}' not yet implemented` };
     }
-    const msg = buildCodecommitJobMessage(ev, 'comment.command', now, envelope.MessageId);
+    const msg = buildCodecommitJobMessage(ev, 'comment.command', now, installationId);
     if (!msg) return { kind: 'ignored', reason: 'missing repositoryName/pullRequestId' };
     const r = await deps.queue.enqueue(msg);
     return { kind: 'enqueued', messageId: r.messageId };

--- a/packages/server/src/handlers/codecommit-webhook.ts
+++ b/packages/server/src/handlers/codecommit-webhook.ts
@@ -103,14 +103,9 @@ function pickPrNumber(ev: CodecommitEvent): number | null {
 /**
  * Build the JobMessage for a CodeCommit PR.
  *
- * Note: `JobMessageSchema` in `core` currently pins
- * `prRef.platform: z.literal('github')` — widening that schema to
- * include `'codecommit'` belongs to a `core` change (out of scope for
- * this handler-only PR). Since the GitHub adapter only consumes
- * `platform: 'github'` jobs, the worker safely ignores any
- * `'codecommit'` jobs that reach it until the schema is widened and a
- * dispatcher routes by platform. The type assertion below is the
- * narrowest possible workaround for the schema mismatch.
+ * `JobMessageSchema.prRef.platform` is now a `'github' | 'codecommit'`
+ * enum (widened in core as the issue #73 follow-on), so we can build
+ * the prRef as a plain typed object without any `unknown` cast.
  */
 function buildCodecommitJobMessage(
   ev: CodecommitEvent,
@@ -122,17 +117,13 @@ function buildCodecommitJobMessage(
   const number = pickPrNumber(ev);
   if (!repo || !number) return null;
   const headSha = ev.sourceCommit;
-  // JobMessageSchema in core currently pins `prRef.platform: z.literal('github')`.
-  // Widening it to include `'codecommit'` is a separate core change; until then
-  // we mint the codecommit value here via an `unknown` round-trip so the
-  // receiver is ready as soon as the schema lifts, and no `any` is introduced.
-  const prRef = {
+  const prRef: JobMessage['prRef'] = {
     platform: 'codecommit',
     owner: '',
     repo,
     number,
     ...(headSha ? { headSha } : {}),
-  } as unknown as JobMessage['prRef'];
+  };
   const msg: JobMessage = {
     jobId: `codecommit:${repo}#${number}@${now.getTime()}`,
     installationId: snsMessageId,

--- a/packages/server/src/handlers/webhook.ts
+++ b/packages/server/src/handlers/webhook.ts
@@ -1,7 +1,6 @@
 import type { JobMessage, QueueClient } from '@review-agent/core';
 import type { Context } from 'hono';
-
-const COMMAND_PREFIX = '@review-agent';
+import { parseCommand } from '../utils/parse-command.js';
 
 export type WebhookHandlerDeps = {
   readonly queue: QueueClient;
@@ -93,16 +92,6 @@ export async function handleWebhook(
   }
 
   return { kind: 'ignored', reason: `unhandled event '${event}'` };
-}
-
-function parseCommand(commentBody: string): string | null {
-  const lower = commentBody.toLowerCase();
-  const idx = lower.indexOf(COMMAND_PREFIX);
-  if (idx < 0) return null;
-  const after = lower.slice(idx + COMMAND_PREFIX.length).trim();
-  const word = after.split(/\s+/, 1)[0];
-  if (!word) return null;
-  return word.replace(/[^a-z]/g, '');
 }
 
 function buildJobMessage(

--- a/packages/server/src/middleware/verify-sns-signature.test.ts
+++ b/packages/server/src/middleware/verify-sns-signature.test.ts
@@ -1,7 +1,8 @@
 import crypto from 'node:crypto';
 import { Hono } from 'hono';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  _clearSnsCertCache,
   buildSnsCanonicalString,
   type SnsMessage,
   type VerifySnsEnv,
@@ -40,6 +41,14 @@ function makeSubscriptionConfirmation(overrides: Partial<SnsMessage> = {}): SnsM
   };
 }
 
+beforeEach(() => {
+  _clearSnsCertCache();
+});
+
+afterEach(() => {
+  _clearSnsCertCache();
+});
+
 describe('buildSnsCanonicalString', () => {
   it('produces the documented canonical string for a Notification with Subject', () => {
     const msg = makeNotification();
@@ -76,10 +85,21 @@ describe('verifySnsMessage', () => {
     expect(ok).toBe(false);
   });
 
-  it('rejects a cert URL not under amazonaws.com', async () => {
+  it('rejects a cert URL not under sns.<region>.amazonaws.com (SEC-7)', async () => {
     const ok = await verifySnsMessage({
       ...makeNotification(),
       SigningCertURL: 'https://evil.example.com/cert.pem',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects a cert URL on a non-sns AWS host (SEC-7 tightening)', async () => {
+    // The pre-fix code accepted any `*.amazonaws.com` host. After
+    // tightening to `sns.<region>.amazonaws.com`, `s3.amazonaws.com`
+    // (or any other AWS service host) must be rejected.
+    const ok = await verifySnsMessage({
+      ...makeNotification(),
+      SigningCertURL: 'https://s3.amazonaws.com/some-bucket/cert.pem',
     });
     expect(ok).toBe(false);
   });
@@ -143,8 +163,13 @@ describe('verifySnsMessage', () => {
     });
     expect(ok).toBe(true);
 
-    // And a tampered canonical string fails.
-    const tampered: SnsMessage = { ...signed, Message: 'tampered' };
+    // And a tampered canonical string fails. Use a *different* cert
+    // URL so the cache (populated by the first call) is not consulted.
+    const tampered: SnsMessage = {
+      ...signed,
+      Message: 'tampered',
+      SigningCertURL: 'https://sns.us-east-2.amazonaws.com/cert.pem',
+    };
     const okBad = await verifySnsMessage(tampered, { fetchCert: async () => publicPem });
     expect(okBad).toBe(false);
   });
@@ -156,6 +181,145 @@ describe('verifySnsMessage', () => {
       },
     }).catch(() => false);
     expect(ok).toBe(false);
+  });
+
+  describe('cert cache (SEC-2)', () => {
+    it('serves a cached PEM on the second verification with the same URL', async () => {
+      const fetchCert = vi.fn().mockResolvedValue('PEM');
+      const verifier = vi.fn().mockReturnValue(true);
+      const msg = makeNotification();
+
+      await verifySnsMessage(msg, { fetchCert, verifySignature: verifier });
+      await verifySnsMessage(msg, { fetchCert, verifySignature: verifier });
+
+      expect(fetchCert).toHaveBeenCalledTimes(1);
+      expect(verifier).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches independently per SigningCertURL', async () => {
+      const fetchCert = vi.fn().mockResolvedValue('PEM');
+      const verifier = vi.fn().mockReturnValue(true);
+      const a = makeNotification({
+        SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert-a.pem',
+      });
+      const b = makeNotification({
+        SigningCertURL: 'https://sns.us-east-2.amazonaws.com/cert-b.pem',
+      });
+
+      await verifySnsMessage(a, { fetchCert, verifySignature: verifier });
+      await verifySnsMessage(b, { fetchCert, verifySignature: verifier });
+      await verifySnsMessage(a, { fetchCert, verifySignature: verifier });
+
+      expect(fetchCert).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-fetches after TTL expires (24h)', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchCert = vi.fn().mockResolvedValue('PEM');
+        const verifier = vi.fn().mockReturnValue(true);
+        const msg = makeNotification();
+
+        await verifySnsMessage(msg, { fetchCert, verifySignature: verifier });
+        // Advance 24h + 1 ms — entry should be expired.
+        vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1_000 + 1);
+        await verifySnsMessage(msg, { fetchCert, verifySignature: verifier });
+
+        expect(fetchCert).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('evicts the oldest entry past the LRU bound', async () => {
+      const fetchCert = vi.fn().mockResolvedValue('PEM');
+      const verifier = vi.fn().mockReturnValue(true);
+
+      // Fill cache with 64 distinct URLs.
+      for (let i = 0; i < 64; i++) {
+        await verifySnsMessage(
+          makeNotification({
+            SigningCertURL: `https://sns.us-east-1.amazonaws.com/cert-${i}.pem`,
+          }),
+          { fetchCert, verifySignature: verifier },
+        );
+      }
+      expect(fetchCert).toHaveBeenCalledTimes(64);
+
+      // 65th distinct URL should evict cert-0.
+      await verifySnsMessage(
+        makeNotification({
+          SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert-99.pem',
+        }),
+        { fetchCert, verifySignature: verifier },
+      );
+      expect(fetchCert).toHaveBeenCalledTimes(65);
+
+      // cert-0 should now miss and re-fetch.
+      await verifySnsMessage(
+        makeNotification({
+          SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert-0.pem',
+        }),
+        { fetchCert, verifySignature: verifier },
+      );
+      expect(fetchCert).toHaveBeenCalledTimes(66);
+    });
+  });
+
+  describe('default fetchCert timeout (SEC-2)', () => {
+    it('passes an AbortSignal with a 5s timeout to fetch()', async () => {
+      const mockFetch = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('PEM', { status: 200 }));
+      try {
+        const ok = await verifySnsMessage(makeNotification(), {
+          // omit fetchCert → exercises the default path.
+          verifySignature: () => true,
+        });
+        expect(ok).toBe(true);
+        const call = mockFetch.mock.calls[0];
+        expect(call).toBeDefined();
+        const init = call?.[1];
+        expect(init).toBeDefined();
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+      } finally {
+        mockFetch.mockRestore();
+      }
+    });
+
+    it('returns false when the default fetch is aborted by an already-aborted signal', async () => {
+      // Stub fetch to honour the AbortSignal — if it is already
+      // aborted at call time, reject immediately. This avoids
+      // sleeping for the real 5s timeout while still proving the
+      // signal wires through end-to-end.
+      const mockFetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        if (signal?.aborted) throw new Error('aborted');
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        });
+      });
+      // Patch AbortSignal.timeout to return an already-aborted signal.
+      const origTimeout = AbortSignal.timeout;
+      AbortSignal.timeout = () => {
+        const ctrl = new AbortController();
+        ctrl.abort();
+        return ctrl.signal;
+      };
+      try {
+        const ok = await verifySnsMessage(
+          {
+            ...makeNotification(),
+            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/timeout.pem',
+          },
+          { verifySignature: () => true },
+        ).catch(() => false);
+        expect(ok).toBe(false);
+      } finally {
+        AbortSignal.timeout = origTimeout;
+        mockFetch.mockRestore();
+      }
+    });
   });
 });
 

--- a/packages/server/src/middleware/verify-sns-signature.test.ts
+++ b/packages/server/src/middleware/verify-sns-signature.test.ts
@@ -1,0 +1,252 @@
+import crypto from 'node:crypto';
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildSnsCanonicalString,
+  type SnsMessage,
+  type VerifySnsEnv,
+  verifySnsMessage,
+  verifySnsSignature,
+} from './verify-sns-signature.js';
+
+function makeNotification(overrides: Partial<SnsMessage> = {}): SnsMessage {
+  return {
+    Type: 'Notification',
+    MessageId: 'mid-1',
+    TopicArn: 'arn:aws:sns:us-east-1:111111111111:t',
+    Subject: 's',
+    Message: 'm',
+    Timestamp: '2026-04-30T00:00:00Z',
+    SignatureVersion: '2',
+    Signature: 'AAAA',
+    SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+    ...overrides,
+  };
+}
+
+function makeSubscriptionConfirmation(overrides: Partial<SnsMessage> = {}): SnsMessage {
+  return {
+    Type: 'SubscriptionConfirmation',
+    MessageId: 'mid-2',
+    TopicArn: 'arn:aws:sns:us-east-1:111111111111:t',
+    Message: 'You have chosen to subscribe',
+    Token: 'tok-abc',
+    SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=tok-abc',
+    Timestamp: '2026-04-30T00:00:00Z',
+    SignatureVersion: '2',
+    Signature: 'BBBB',
+    SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+    ...overrides,
+  };
+}
+
+describe('buildSnsCanonicalString', () => {
+  it('produces the documented canonical string for a Notification with Subject', () => {
+    const msg = makeNotification();
+    const got = buildSnsCanonicalString(msg);
+    expect(got).toBe(
+      'Message\nm\nMessageId\nmid-1\nSubject\ns\nTimestamp\n2026-04-30T00:00:00Z\nTopicArn\narn:aws:sns:us-east-1:111111111111:t\nType\nNotification\n',
+    );
+  });
+
+  it('omits Subject when absent', () => {
+    const { Subject: _subject, ...rest } = makeNotification();
+    const msg = rest as SnsMessage;
+    const got = buildSnsCanonicalString(msg);
+    expect(got).not.toContain('Subject');
+    expect(got).toContain('Type\nNotification\n');
+  });
+
+  it('produces the documented canonical string for SubscriptionConfirmation', () => {
+    const msg = makeSubscriptionConfirmation();
+    const got = buildSnsCanonicalString(msg);
+    expect(got).toContain('SubscribeURL\nhttps://');
+    expect(got).toContain('Token\ntok-abc\n');
+    expect(got).toContain('Type\nSubscriptionConfirmation\n');
+  });
+});
+
+describe('verifySnsMessage', () => {
+  it('returns false for unknown SignatureVersion', async () => {
+    const ok = await verifySnsMessage({
+      ...makeNotification(),
+      // biome-ignore lint/suspicious/noExplicitAny: deliberate bad version
+      SignatureVersion: '99' as any,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects a cert URL not under amazonaws.com', async () => {
+    const ok = await verifySnsMessage({
+      ...makeNotification(),
+      SigningCertURL: 'https://evil.example.com/cert.pem',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects an http (non-https) cert URL', async () => {
+    const ok = await verifySnsMessage({
+      ...makeNotification(),
+      SigningCertURL: 'http://sns.us-east-1.amazonaws.com/cert.pem',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects a syntactically invalid cert URL', async () => {
+    const ok = await verifySnsMessage({
+      ...makeNotification(),
+      SigningCertURL: 'not a url',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('passes the canonical string and base64 signature through to the verifier', async () => {
+    const verifier = vi.fn().mockReturnValue(true);
+    const ok = await verifySnsMessage(makeNotification(), {
+      fetchCert: async () => 'PEM',
+      verifySignature: verifier,
+    });
+    expect(ok).toBe(true);
+    const call = verifier.mock.calls[0]?.[0];
+    expect(call.certificatePem).toBe('PEM');
+    expect(call.signatureBase64).toBe('AAAA');
+    expect(call.signatureVersion).toBe('2');
+    expect(call.canonical).toContain('Type\nNotification\n');
+  });
+
+  it('returns false when the injected verifier rejects', async () => {
+    const ok = await verifySnsMessage(makeNotification(), {
+      fetchCert: async () => 'PEM',
+      verifySignature: () => false,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('uses a real RSA keypair end-to-end with the default verifier', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    // Produce a self-signed cert PEM from the key. For testing the
+    // default verifier path we just need a public-key PEM since
+    // `crypto.createVerify(...).verify()` accepts PEM-encoded public
+    // keys as well as certificates.
+    const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+    const msg = makeNotification();
+    const canonical = buildSnsCanonicalString(msg);
+    const signer = crypto.createSign('RSA-SHA256');
+    signer.update(canonical, 'utf8');
+    const signature = signer.sign(privateKey, 'base64');
+
+    const signed: SnsMessage = { ...msg, Signature: signature };
+    const ok = await verifySnsMessage(signed, {
+      fetchCert: async () => publicPem,
+      // omit verifySignature → exercises the default node:crypto path.
+    });
+    expect(ok).toBe(true);
+
+    // And a tampered canonical string fails.
+    const tampered: SnsMessage = { ...signed, Message: 'tampered' };
+    const okBad = await verifySnsMessage(tampered, { fetchCert: async () => publicPem });
+    expect(okBad).toBe(false);
+  });
+
+  it('returns false when fetchCert throws', async () => {
+    const ok = await verifySnsMessage(makeNotification(), {
+      fetchCert: async () => {
+        throw new Error('boom');
+      },
+    }).catch(() => false);
+    expect(ok).toBe(false);
+  });
+});
+
+function buildApp() {
+  const app = new Hono<VerifySnsEnv>();
+  app.post(
+    '/sns',
+    verifySnsSignature({
+      fetchCert: async () => 'PEM',
+      verifySignature: () => true,
+    }),
+    (c) => c.json({ ok: true, type: c.get('snsMessage').Type }),
+  );
+  return app;
+}
+
+describe('verifySnsSignature middleware', () => {
+  it('accepts a valid Notification and exposes parsed message on context', async () => {
+    const res = await buildApp().request('/sns', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(makeNotification()),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, type: 'Notification' });
+  });
+
+  it('rejects with 400 on malformed JSON', async () => {
+    const res = await buildApp().request('/sns', { method: 'POST', body: 'not-json' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'bad request' });
+  });
+
+  it('rejects with 400 when required fields are missing', async () => {
+    const res = await buildApp().request('/sns', {
+      method: 'POST',
+      body: JSON.stringify({ Type: 'Notification' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects with 400 on unknown Type', async () => {
+    const res = await buildApp().request('/sns', {
+      method: 'POST',
+      body: JSON.stringify({ ...makeNotification(), Type: 'Weird' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects with 400 on bad SignatureVersion', async () => {
+    const res = await buildApp().request('/sns', {
+      method: 'POST',
+      body: JSON.stringify({ ...makeNotification(), SignatureVersion: '7' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects with 401 when the verifier returns false', async () => {
+    const app = new Hono<VerifySnsEnv>();
+    app.post(
+      '/sns',
+      verifySnsSignature({
+        fetchCert: async () => 'PEM',
+        verifySignature: () => false,
+      }),
+      (c) => c.json({ ok: true }),
+    );
+    const res = await app.request('/sns', {
+      method: 'POST',
+      body: JSON.stringify(makeNotification()),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('rejects with 401 when verifier throws', async () => {
+    const app = new Hono<VerifySnsEnv>();
+    app.post(
+      '/sns',
+      verifySnsSignature({
+        fetchCert: async () => 'PEM',
+        verifySignature: () => {
+          throw new Error('verify boom');
+        },
+      }),
+      (c) => c.json({ ok: true }),
+    );
+    const res = await app.request('/sns', {
+      method: 'POST',
+      body: JSON.stringify(makeNotification()),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/middleware/verify-sns-signature.ts
+++ b/packages/server/src/middleware/verify-sns-signature.ts
@@ -7,7 +7,7 @@ import { createMiddleware } from 'hono/factory';
  * SNS delivers signed JSON envelopes over HTTP(S). Each envelope contains
  * a `Signature` (base64), a `SignatureVersion` (`1` = SHA1, `2` = SHA256),
  * and a `SigningCertURL` pointing at an AWS-hosted X.509 certificate
- * (`*.amazonaws.com`). To verify:
+ * (`sns.<region>.amazonaws.com`). To verify:
  *
  * 1. Build a canonical string from a fixed, version-specific subset of
  *    fields in fixed order, each followed by `\n`.
@@ -64,7 +64,8 @@ export type VerifyFn = (params: {
 export type VerifySnsSignatureOpts = {
   /**
    * Custom certificate fetcher. Defaults to `fetch(url).then(r => r.text())`
-   * but is overridden in tests to a static map.
+   * with a 5-second `AbortSignal.timeout`; overridden in tests to a static
+   * map.
    */
   readonly fetchCert?: FetchCert;
   /**
@@ -73,15 +74,89 @@ export type VerifySnsSignatureOpts = {
    */
   readonly verifySignature?: VerifyFn;
   /**
-   * Allowlist for the certificate host. AWS publishes signing certs only
-   * from `*.amazonaws.com`. We default to that suffix to prevent
-   * spoofing the cert URL to attacker-controlled hosts. Tests can
-   * pass an empty array to disable the check; production should not.
+   * Allowlist regex for the certificate host. AWS publishes signing certs
+   * only from `sns.<region>.amazonaws.com`. The default tightened regex
+   * (per SEC-7 audit) rejects any other `*.amazonaws.com` host so that
+   * e.g. `s3.amazonaws.com/anything` cannot host a cert. Tests can pass
+   * a wider pattern to disable the check; production should not.
    */
-  readonly allowedCertHostSuffixes?: ReadonlyArray<string>;
+  readonly allowedCertHostPattern?: RegExp;
 };
 
-const DEFAULT_CERT_HOST_SUFFIXES: ReadonlyArray<string> = ['.amazonaws.com'];
+/**
+ * Tightened host allowlist: only `sns.<region>.amazonaws.com`.
+ *
+ * Prior to the SEC-7 audit fix this was a generic `*.amazonaws.com`
+ * suffix match, which would have accepted certs hosted on unrelated
+ * AWS service domains.
+ */
+const DEFAULT_CERT_HOST_PATTERN = /^sns\.[a-z0-9-]+\.amazonaws\.com$/;
+
+const DEFAULT_CERT_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * In-memory LRU + TTL cache for `SigningCertURL` → PEM lookups.
+ *
+ * AWS rotates SNS signing certificates infrequently (months to years),
+ * so caching them aggressively per receiver process avoids a `fetch()`
+ * on every webhook delivery — without that cache, a sustained spike in
+ * SNS deliveries would issue a corresponding spike in egress traffic
+ * to `sns.<region>.amazonaws.com` and noticeably inflate worst-case
+ * verification latency. SEC-2 audit fix.
+ *
+ * Cache is process-local (Lambda warm-container scope). TTL is 24 hours
+ * so a slowly-rotated cert is picked up within a day even without a
+ * restart. Maximum entry count is small because we only ever expect
+ * a handful of distinct cert URLs in practice (one per region, with
+ * occasional rotation), but bound it anyway as a memory-safety floor.
+ */
+const CERT_CACHE_TTL_MS = 24 * 60 * 60 * 1_000;
+const CERT_CACHE_MAX_ENTRIES = 64;
+
+type CertCacheEntry = {
+  readonly pem: string;
+  readonly expiresAt: number;
+};
+
+const certCache = new Map<string, CertCacheEntry>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+/**
+ * Reset the in-memory cert cache. Intended for tests.
+ */
+export function _clearSnsCertCache(): void {
+  certCache.clear();
+}
+
+/**
+ * Returns the cached PEM for `url` if it is fresh; otherwise `null`.
+ * Side-effect: refreshes the entry's recency (LRU promotion) when a
+ * cache hit occurs. Expired entries are evicted on read.
+ */
+function getCachedCert(url: string): string | null {
+  const hit = certCache.get(url);
+  if (!hit) return null;
+  if (hit.expiresAt <= nowMs()) {
+    certCache.delete(url);
+    return null;
+  }
+  // LRU touch: re-insert to move to the tail of the Map's insertion order.
+  certCache.delete(url);
+  certCache.set(url, hit);
+  return hit.pem;
+}
+
+function setCachedCert(url: string, pem: string): void {
+  if (certCache.size >= CERT_CACHE_MAX_ENTRIES && !certCache.has(url)) {
+    // Evict the oldest entry (Map iteration order = insertion order).
+    const oldest = certCache.keys().next().value;
+    if (oldest !== undefined) certCache.delete(oldest);
+  }
+  certCache.set(url, { pem, expiresAt: nowMs() + CERT_CACHE_TTL_MS });
+}
 
 /**
  * Builds the canonical string-to-sign for SNS message verification.
@@ -109,7 +184,7 @@ export function buildSnsCanonicalString(msg: SnsMessage): string {
 }
 
 const defaultFetchCert: FetchCert = async (url) => {
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(DEFAULT_CERT_FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`SNS cert fetch failed: ${res.status}`);
   }
@@ -142,22 +217,24 @@ export async function verifySnsMessage(
   if (msg.SignatureVersion !== '1' && msg.SignatureVersion !== '2') {
     return false;
   }
-  const allow = opts.allowedCertHostSuffixes ?? DEFAULT_CERT_HOST_SUFFIXES;
-  if (allow.length > 0) {
-    let parsed: URL;
-    try {
-      parsed = new URL(msg.SigningCertURL);
-    } catch {
-      return false;
-    }
-    if (parsed.protocol !== 'https:') return false;
-    const host = parsed.hostname;
-    const ok = allow.some((s) => host === s.replace(/^\./, '') || host.endsWith(s));
-    if (!ok) return false;
+  const pattern = opts.allowedCertHostPattern ?? DEFAULT_CERT_HOST_PATTERN;
+  let parsed: URL;
+  try {
+    parsed = new URL(msg.SigningCertURL);
+  } catch {
+    return false;
   }
+  if (parsed.protocol !== 'https:') return false;
+  if (!pattern.test(parsed.hostname)) return false;
+
   const fetcher = opts.fetchCert ?? defaultFetchCert;
   const verifier = opts.verifySignature ?? defaultVerifySignature;
-  const cert = await fetcher(msg.SigningCertURL);
+
+  let cert = getCachedCert(msg.SigningCertURL);
+  if (cert === null) {
+    cert = await fetcher(msg.SigningCertURL);
+    setCachedCert(msg.SigningCertURL, cert);
+  }
   const canonical = buildSnsCanonicalString(msg);
   return verifier({
     canonical,

--- a/packages/server/src/middleware/verify-sns-signature.ts
+++ b/packages/server/src/middleware/verify-sns-signature.ts
@@ -1,0 +1,227 @@
+import crypto from 'node:crypto';
+import { createMiddleware } from 'hono/factory';
+
+/**
+ * AWS SNS HTTPS subscription signature verification.
+ *
+ * SNS delivers signed JSON envelopes over HTTP(S). Each envelope contains
+ * a `Signature` (base64), a `SignatureVersion` (`1` = SHA1, `2` = SHA256),
+ * and a `SigningCertURL` pointing at an AWS-hosted X.509 certificate
+ * (`*.amazonaws.com`). To verify:
+ *
+ * 1. Build a canonical string from a fixed, version-specific subset of
+ *    fields in fixed order, each followed by `\n`.
+ * 2. Fetch the signing certificate from `SigningCertURL`.
+ * 3. Verify `Signature` against the canonical string using
+ *    `RSA-SHA1` or `RSA-SHA256` and the certificate's public key.
+ *
+ * Reference:
+ * https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
+ *
+ * Spec §7.1 / line 821: "CodeCommit (via SNS): use AWS SNS message
+ * signature verification with SigV4". (AWS docs call the scheme
+ * "Signature" not "SigV4" but the issue body uses that name.)
+ *
+ * To keep tests offline and deterministic, the middleware accepts
+ * injectable `fetchCert` and `verifySignature` functions; defaults
+ * call out to the real network / `node:crypto` only at runtime.
+ */
+
+export type SnsMessageType =
+  | 'Notification'
+  | 'SubscriptionConfirmation'
+  | 'UnsubscribeConfirmation';
+
+export type SnsMessage = {
+  readonly Type: SnsMessageType;
+  readonly MessageId: string;
+  readonly TopicArn: string;
+  readonly Timestamp: string;
+  readonly Signature: string;
+  readonly SignatureVersion: '1' | '2';
+  readonly SigningCertURL: string;
+  readonly Message?: string;
+  readonly Subject?: string;
+  readonly Token?: string;
+  readonly SubscribeURL?: string;
+};
+
+export type VerifySnsEnv = {
+  Variables: {
+    snsRawBody: string;
+    snsMessage: SnsMessage;
+  };
+};
+
+export type FetchCert = (url: string) => Promise<string>;
+export type VerifyFn = (params: {
+  readonly canonical: string;
+  readonly signatureBase64: string;
+  readonly signatureVersion: '1' | '2';
+  readonly certificatePem: string;
+}) => boolean;
+
+export type VerifySnsSignatureOpts = {
+  /**
+   * Custom certificate fetcher. Defaults to `fetch(url).then(r => r.text())`
+   * but is overridden in tests to a static map.
+   */
+  readonly fetchCert?: FetchCert;
+  /**
+   * Custom verifier. Defaults to the `node:crypto` implementation.
+   * Tests override this to skip RSA entirely.
+   */
+  readonly verifySignature?: VerifyFn;
+  /**
+   * Allowlist for the certificate host. AWS publishes signing certs only
+   * from `*.amazonaws.com`. We default to that suffix to prevent
+   * spoofing the cert URL to attacker-controlled hosts. Tests can
+   * pass an empty array to disable the check; production should not.
+   */
+  readonly allowedCertHostSuffixes?: ReadonlyArray<string>;
+};
+
+const DEFAULT_CERT_HOST_SUFFIXES: ReadonlyArray<string> = ['.amazonaws.com'];
+
+/**
+ * Builds the canonical string-to-sign for SNS message verification.
+ * AWS specifies the exact key set and ordering, with each `key\nvalue\n`
+ * pair joined.
+ */
+export function buildSnsCanonicalString(msg: SnsMessage): string {
+  const keys: ReadonlyArray<keyof SnsMessage> =
+    msg.Type === 'Notification'
+      ? msg.Subject !== undefined
+        ? ['Message', 'MessageId', 'Subject', 'Timestamp', 'TopicArn', 'Type']
+        : ['Message', 'MessageId', 'Timestamp', 'TopicArn', 'Type']
+      : ['Message', 'MessageId', 'SubscribeURL', 'Timestamp', 'Token', 'TopicArn', 'Type'];
+
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = msg[k];
+    if (v === undefined) continue;
+    parts.push(k);
+    parts.push('\n');
+    parts.push(String(v));
+    parts.push('\n');
+  }
+  return parts.join('');
+}
+
+const defaultFetchCert: FetchCert = async (url) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`SNS cert fetch failed: ${res.status}`);
+  }
+  return res.text();
+};
+
+const defaultVerifySignature: VerifyFn = ({
+  canonical,
+  signatureBase64,
+  signatureVersion,
+  certificatePem,
+}) => {
+  const algo = signatureVersion === '2' ? 'RSA-SHA256' : 'RSA-SHA1';
+  const verifier = crypto.createVerify(algo);
+  verifier.update(canonical, 'utf8');
+  verifier.end();
+  return verifier.verify(certificatePem, signatureBase64, 'base64');
+};
+
+/**
+ * Pure helper that performs the full verification on a parsed envelope.
+ * Returns `true` iff the signature is valid for the given message.
+ * Throws (caught by middleware) when the cert URL is malformed or the
+ * cert host fails the allowlist.
+ */
+export async function verifySnsMessage(
+  msg: SnsMessage,
+  opts: VerifySnsSignatureOpts = {},
+): Promise<boolean> {
+  if (msg.SignatureVersion !== '1' && msg.SignatureVersion !== '2') {
+    return false;
+  }
+  const allow = opts.allowedCertHostSuffixes ?? DEFAULT_CERT_HOST_SUFFIXES;
+  if (allow.length > 0) {
+    let parsed: URL;
+    try {
+      parsed = new URL(msg.SigningCertURL);
+    } catch {
+      return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname;
+    const ok = allow.some((s) => host === s.replace(/^\./, '') || host.endsWith(s));
+    if (!ok) return false;
+  }
+  const fetcher = opts.fetchCert ?? defaultFetchCert;
+  const verifier = opts.verifySignature ?? defaultVerifySignature;
+  const cert = await fetcher(msg.SigningCertURL);
+  const canonical = buildSnsCanonicalString(msg);
+  return verifier({
+    canonical,
+    signatureBase64: msg.Signature,
+    signatureVersion: msg.SignatureVersion,
+    certificatePem: cert,
+  });
+}
+
+/**
+ * Hono middleware that:
+ * 1. Reads the raw request body and parses it as a JSON SNS envelope.
+ * 2. Calls `verifySnsMessage` (injectable in tests).
+ * 3. On success, stashes the raw body + parsed message on the context
+ *    so downstream handlers can act on them without re-parsing.
+ *
+ * Rejects with `401 { error: 'unauthorized' }` on any signature failure
+ * and `400 { error: 'bad request' }` on malformed JSON / missing fields.
+ * Error bodies are identical between failure modes so a probe cannot
+ * distinguish "missing signature" from "bad signature".
+ */
+export function verifySnsSignature(opts: VerifySnsSignatureOpts = {}) {
+  return createMiddleware<VerifySnsEnv>(async (c, next) => {
+    const raw = await c.req.text();
+    let parsed: SnsMessage;
+    try {
+      const obj = JSON.parse(raw) as Partial<SnsMessage>;
+      if (
+        typeof obj.Type !== 'string' ||
+        typeof obj.MessageId !== 'string' ||
+        typeof obj.TopicArn !== 'string' ||
+        typeof obj.Timestamp !== 'string' ||
+        typeof obj.Signature !== 'string' ||
+        typeof obj.SigningCertURL !== 'string'
+      ) {
+        return c.json({ error: 'bad request' }, 400);
+      }
+      if (
+        obj.Type !== 'Notification' &&
+        obj.Type !== 'SubscriptionConfirmation' &&
+        obj.Type !== 'UnsubscribeConfirmation'
+      ) {
+        return c.json({ error: 'bad request' }, 400);
+      }
+      const sv = obj.SignatureVersion;
+      if (sv !== '1' && sv !== '2') {
+        return c.json({ error: 'bad request' }, 400);
+      }
+      parsed = obj as SnsMessage;
+    } catch {
+      return c.json({ error: 'bad request' }, 400);
+    }
+
+    let ok = false;
+    try {
+      ok = await verifySnsMessage(parsed, opts);
+    } catch {
+      ok = false;
+    }
+    if (!ok) {
+      return c.json({ error: 'unauthorized' }, 401);
+    }
+    c.set('snsRawBody', raw);
+    c.set('snsMessage', parsed);
+    await next();
+  });
+}

--- a/packages/server/src/utils/namespace-delivery-id.test.ts
+++ b/packages/server/src/utils/namespace-delivery-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { namespaceDeliveryId } from './namespace-delivery-id.js';
+
+describe('namespaceDeliveryId', () => {
+  it('prefixes github delivery ids with gh:', () => {
+    expect(namespaceDeliveryId('github', 'dlv-1')).toBe('gh:dlv-1');
+  });
+
+  it('prefixes codecommit delivery ids with sns:', () => {
+    expect(namespaceDeliveryId('codecommit', 'm-1')).toBe('sns:m-1');
+  });
+
+  it('does not collide when the same id is namespaced for two platforms', () => {
+    const id = 'shared-uuid';
+    expect(namespaceDeliveryId('github', id)).not.toBe(namespaceDeliveryId('codecommit', id));
+  });
+});

--- a/packages/server/src/utils/namespace-delivery-id.ts
+++ b/packages/server/src/utils/namespace-delivery-id.ts
@@ -1,0 +1,25 @@
+/**
+ * Namespace prefix for the shared `webhook_deliveries.delivery_id` column.
+ *
+ * GitHub `X-GitHub-Delivery` is a server-issued UUID, and SNS `MessageId`
+ * is likewise a UUID. They live in distinct ID spaces, but a probabilistic
+ * UUID collision between the two would dedup the wrong delivery if both
+ * platforms wrote raw IDs into the same column.
+ *
+ * Per the SEC-3 audit finding, the CodeCommit bridge prefixes every SNS
+ * `MessageId` with `sns:` before exposing it to the shared idempotency
+ * middleware. GitHub deliveries continue to write the bare `delivery_id`
+ * for backwards compatibility with existing rows — the namespace is one-
+ * sided, asymmetric by design (see `docs/deployment/aws.md` and the
+ * `app.ts` bridge for details).
+ */
+export type DeliveryPlatform = 'github' | 'codecommit';
+
+const PLATFORM_PREFIX: Readonly<Record<DeliveryPlatform, string>> = {
+  github: 'gh:',
+  codecommit: 'sns:',
+};
+
+export function namespaceDeliveryId(platform: DeliveryPlatform, id: string): string {
+  return `${PLATFORM_PREFIX[platform]}${id}`;
+}

--- a/packages/server/src/utils/parse-command.test.ts
+++ b/packages/server/src/utils/parse-command.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { COMMAND_PREFIX, parseCommand } from './parse-command.js';
+
+describe('parseCommand', () => {
+  it('returns null when prefix is absent', () => {
+    expect(parseCommand('hello world')).toBeNull();
+  });
+
+  it('returns null when prefix is present but no command follows', () => {
+    expect(parseCommand('@review-agent')).toBeNull();
+    expect(parseCommand('@review-agent   ')).toBeNull();
+  });
+
+  it('extracts the first word after the prefix', () => {
+    expect(parseCommand('@review-agent review')).toBe('review');
+  });
+
+  it('is case-insensitive on the prefix and command', () => {
+    expect(parseCommand('@ReView-AGent REVIEW')).toBe('review');
+  });
+
+  it('ignores leading text before the prefix', () => {
+    expect(parseCommand('thanks! @review-agent review please')).toBe('review');
+  });
+
+  it('strips trailing punctuation from the command', () => {
+    expect(parseCommand('@review-agent review.')).toBe('review');
+    expect(parseCommand('@review-agent review!')).toBe('review');
+  });
+
+  it('strips embedded non-alpha characters from the command', () => {
+    expect(parseCommand('@review-agent re-view')).toBe('review');
+  });
+
+  it('returns the remaining lowercase letters when prefix is followed by only punctuation', () => {
+    expect(parseCommand('@review-agent !!!')).toBe('');
+  });
+
+  it('exports the canonical prefix string', () => {
+    expect(COMMAND_PREFIX).toBe('@review-agent');
+  });
+});

--- a/packages/server/src/utils/parse-command.ts
+++ b/packages/server/src/utils/parse-command.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared `@review-agent <command>` parser.
+ *
+ * Extracted from `handlers/webhook.ts` so that the CodeCommit receiver
+ * (`handlers/codecommit-webhook.ts`) can reuse the exact same command
+ * extraction logic as the GitHub handler. Behaviour is preserved
+ * verbatim:
+ *
+ * - Matching is case-insensitive on the prefix (`@review-agent`).
+ * - The first whitespace-delimited token after the prefix is the command.
+ * - Non-`[a-z]` characters are stripped from the command (so trailing
+ *   punctuation like `review.` becomes `review`).
+ * - Returns `null` when the prefix is absent or no command word follows.
+ */
+
+export const COMMAND_PREFIX = '@review-agent';
+
+export function parseCommand(commentBody: string): string | null {
+  const lower = commentBody.toLowerCase();
+  const idx = lower.indexOf(COMMAND_PREFIX);
+  if (idx < 0) return null;
+  const after = lower.slice(idx + COMMAND_PREFIX.length).trim();
+  const word = after.split(/\s+/, 1)[0];
+  if (!word) return null;
+  return word.replace(/[^a-z]/g, '');
+}

--- a/packages/server/src/workspace.test.ts
+++ b/packages/server/src/workspace.test.ts
@@ -25,6 +25,12 @@ function makeDiff(files: ReadonlyArray<Partial<Diff['files'][number]>>): Diff {
 function makeVcs(overrides: Partial<VCS> = {}): VCS {
   return {
     platform: 'github',
+    capabilities: {
+      clone: true,
+      stateComment: 'native',
+      approvalEvent: 'github',
+      commitMessages: true,
+    },
     getPR: vi.fn(),
     getDiff: vi.fn(),
     getFile: vi.fn(),
@@ -216,6 +222,39 @@ describe('provisionWorkspace — strategy: sparse-clone', () => {
     // Sparse paths reduced to unique parent dirs.
     expect([...(opts.sparsePaths ?? [])].sort()).toEqual(['docs', 'src']);
     await handle.cleanup();
+  });
+
+  it('refuses with a typed error when capabilities.clone is false (CodeCommit-style adapter)', async () => {
+    const cloneRepo = vi.fn<VCS['cloneRepo']>(async () => undefined);
+    const vcs = makeVcs({
+      capabilities: {
+        clone: false,
+        stateComment: 'postgres-only',
+        approvalEvent: 'codecommit',
+        commitMessages: false,
+      },
+      platform: 'codecommit',
+      cloneRepo,
+    });
+    await expect(
+      provisionWorkspace(
+        {
+          strategy: 'sparse-clone',
+          vcs,
+          ref,
+          headSha: 'H',
+          diff: makeDiff([{ path: 'src/a.ts' }]),
+        },
+        {
+          tmpdir: () => '/tmp-fake',
+          mkdtemp: vi.fn(async (prefix) => `${prefix}clone`),
+          mkdir: vi.fn(async () => undefined) as never,
+          writeFile: vi.fn(async () => undefined) as never,
+          rm: vi.fn(async () => undefined),
+        },
+      ),
+    ).rejects.toThrow(/sparse-clone.*clone capability.*codecommit/);
+    expect(cloneRepo).not.toHaveBeenCalled();
   });
 
   it('drops denylisted paths from the sparse-checkout pattern set', async () => {

--- a/packages/server/src/workspace.ts
+++ b/packages/server/src/workspace.ts
@@ -120,6 +120,20 @@ async function sparseClone(input: ProvisionWorkspaceInput, dir: string): Promise
   // git plumbing as Action mode (cloneWithStrategy in
   // platform-github). Sparse paths come from the diff so we only
   // materialize the directories the LLM may need to read.
+  //
+  // Capability gate: refuse before touching the adapter when the
+  // platform advertises no clone support (CodeCommit). The adapter's
+  // own `cloneRepo` throws as defense-in-depth; this check produces a
+  // clearer operator-facing error that names the config decision
+  // ("strategy: 'sparse-clone' requires clone capability") rather
+  // than the lower-level "CodeCommit clone is not supported" message.
+  if (!input.vcs.capabilities.clone) {
+    throw new Error(
+      `workspace strategy 'sparse-clone' requires VCS clone capability, ` +
+        `but platform '${input.vcs.platform}' advertises clone: false. ` +
+        `Use strategy: 'contents-api' or 'none' for this platform.`,
+    );
+  }
   const sparsePaths = uniqueParentDirs(
     input.diff.files.filter((f) => pathIsAllowed(f.path)).map((f) => f.path),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@review-agent/llm':
         specifier: workspace:*
         version: link:../llm
+      '@review-agent/platform-codecommit':
+        specifier: workspace:*
+        version: link:../platform-codecommit
       '@review-agent/platform-github':
         specifier: workspace:*
         version: link:../platform-github


### PR DESCRIPTION
## Summary

- v1.1 マイルストーンの全 8 件の CodeCommit 関連 issue (#73–#80) を実装し、event receiver (SNS → SQS) / approval-state マッピング / CLI `--platform codecommit` / eval fixtures / IAM drift test / VCS 抽象化 (capabilities + role split + platform registry) / DR runbook / out-of-scope spec 整理を develop ブランチに集約。
- ロールアウト時の隠れた gap (CLI 配線、JobMessageSchema、IAM PENDING) を解消する 3 件のフォローオンと、3 並列で実施した多面的監査 (security / functional correctness / spec compliance) で発見した security finding 7 件 + correctness finding 3 件 + spec drift 3 件を確定修正。
- typecheck / lint / test:coverage / build がリポ全体で green。テスト合計 952 passed (server 134 / core 194 / platform-codecommit 39 / platform-github 90 / cli 62 / runner 193 等)、新規テストは server +64 / core +19 / platform-codecommit +24 等で v1.0.1 比 ~130 件増。

## v1.1 issues — 8件全て close 対象

| Issue | 内容 | 主要 commit |
|---|---|---|
| #79 | docs(specs): CodeCommit out-of-scope items 整理 (§1.2 GHES note, §5.2.1, §22.1, PRD §2.3 cross-ref) | `003affa` |
| #77 | docs(operations): CodeCommit DR runbook (Postgres-canonical, RPO/RTO 階層, audit-chain verify, manual re-review 手順) | `e4ad2ef` |
| #80 | refactor(core,platform-*): VCS 抽象化 (VcsCapabilities + Reader/Writer/StateStore role split + platform registry) | `c70ee3d` |
| #76 | feat(eval): CodeCommit golden PR fixtures 5 件 + promptfoo coverage | `037e264` |
| #78 | test(platform-codecommit): IAM permissions ↔ SDK Command drift test | `d91b0aa` (+ spec §8.4 parity を `1512fa1` で追加) |
| #74 | feat(platform-codecommit,config): review.event → UpdatePullRequestApprovalState 配線 (opt-in `codecommit.approvalState: 'managed'`) | `c1a5b2a` |
| #75 | feat(cli): `--platform codecommit` (AWS credential chain), `recover sync-state` short-circuit | `e7eb5e1` |
| #73 | feat(server,platform-codecommit): CodeCommit event receiver (SNS HTTPS subscription → SQS, parseCommand 抽出, SNS RSA-SHA 検証) | `d04755e` |

## v1.1 フォローオン (gap 解消)

| 内容 | Commit |
|---|---|
| chore(platform-codecommit): `UpdatePullRequestApprovalStateCommand` を PENDING_COMMANDS から削除 (#74 で wire 済みのため) | `d8954d7` |
| chore(core,server): `JobMessageSchema.prRef.platform` を `z.enum(['github','codecommit'])` に拡張 + `codecommit-webhook.ts` の unknown cast 除去 | `ca4a037` |
| fix(cli): `config.codecommit.approvalState` を `createCodecommitVCS` に配線 (#74 wire-through) | `ca4a037` 内に bundled |

## 監査での発見と修正 (multi-agent audit-driven)

3 並列 (security / functional correctness / spec compliance) で監査し、計 18 件の finding を集約。Critical + High + Spec-Blocker の 13 件を 3 並列で修正:

| Finding | 重大度 | Commit |
|---|---|---|
| SEC-1 SNS SubscriptionConfirmation に TopicArn allowlist 不在 → 攻撃者 topic を購読確認できてしまう | 🔴 Critical | `4e160ac` |
| SEC-2 cert refetch DoS + fetch timeout 無し | 🔴 Critical | `4e160ac` |
| SEC-3 idempotency namespace 衝突 (gh delivery_id ↔ SNS MessageId UUID 衝突) | 🔴 Critical | `4e160ac` |
| FUNC C-1 `installationId = SNS MessageId` (UUID) → DB tenancy で必ず throw、CodeCommit job 実行不能 | 🔴 Critical | `4e160ac` (EventBridge `account` を numeric installationId として導出) |
| SPEC Blocker 1 §8.4 から `codecommit:GetCommentsForPullRequest` 抜け | 🔴 Blocker | `1512fa1` |
| SEC-4 `prRef.owner: ''` が github にも適用、stateId 衝突 | 🟠 High | `202fd0a` (Zod discriminatedUnion) |
| SEC-5 `defaultCloneUrl` で empty owner の場合 token が malformed URL に interpolate される | 🟠 High | `202fd0a` (defense-in-depth guard) |
| SEC-6 approval-state warn log で IAM ARN / account ID 漏洩 | 🟠 High | `1512fa1` (`err.name` のみ) |
| SEC-7 cert host suffix-match too loose (`*.amazonaws.com` 全許可) | 🟡 Medium | `4e160ac` (`^sns\.[a-z0-9-]+\.amazonaws\.com\$` regex) |
| FUNC M-1 `pullRequestId` の `isInteger` チェックでは unsafe integer を通す | 🟡 Medium | `4e160ac` (`isSafeInteger`) |
| FUNC M-2 SubscriptionConfirmation が idempotency 経由で dedup される | 🟡 Medium | `4e160ac` (subscription-control は idempotency 前で短絡) |
| SPEC Should 3 §7.1 が SNS message signing を "SigV4" と誤記載 | 🟡 Medium | `1512fa1` ("RSA-SHA1/SHA256 signing-cert scheme") |
| SPEC Should 5 iam-drift test に spec §8.4 parity 検査なし | 🟡 Medium | `1512fa1` (spec §8.4 をパース→ `EXPECTED_PERMISSIONS` 存在を assert) |

## 既知の未対応 (本 PR スコープ外、follow-up issue 推奨)

| 項目 | 内容 |
|---|---|
| **SPEC Blocker 2** (#80 AC 未充足) | `platform registry` は core で実装・self-register まで完了しているが、CLI / action / server の VCS 構築箇所が hard-coded factory 呼び出しのまま (`getPlatform(prRef.platform).create(...)` 経由になっていない)。docs と実装の乖離。 |
| **FUNC H-1** | `capabilities.stateComment === 'postgres-only'` の routing が未実装 → CodeCommit CLI/Action 経路で review state が silently 失われる。Postgres mirror (`@review-agent/db`) 経由を分岐すべき。 |
| **FUNC H-2** | server worker handler の CodeCommit composition (config → `createCodecommitVCS({approvalState})`) の in-repo helper / sample が無く operator がドキュメント単独では詰む。`docs/deployment/aws.md` に code sample 追加か `createCodecommitJobHandler(deps)` export。 |
| **FUNC H-3** | `worker.ts` `shouldDebounce` の stateId キーに `installationId` 不在 (pre-existing) → account 跨ぎで同名リポ衝突。`${installationId}:${prId}` に統一推奨。 |
| **SEC-8** | static `capabilities.approvalEvent: 'codecommit'` は `approvalState: 'off'` 時に実態と乖離。runtime-derived 化、または `approvalEventSupported` / `approvalEventEnabled` の二段化を検討。 |
| **Test gaps T-1/2/3** | (1) adapter self-registration の動的 import 検証、(2) Notification の異常入力 (`pullRequestId: -5` / `repositoryName: ''` / unsafe int)、(3) `/webhook/codecommit` の e2e idempotency 検証。 |

## Test plan

- [ ] CI で `pnpm typecheck && pnpm lint && pnpm test:coverage && pnpm build` が全 12 パッケージで green。
- [ ] `pnpm test` の合計が **952 passed (5 skipped)**。新規追加分:
    - core 194 (+19 from main): VCS abstraction / platforms registry / queue schema 拡張 / discriminator 検証
    - platform-codecommit 39 (+24): adapter capability / approval-state mapping / iam-drift / spec §8.4 parity
    - server 134 (+64): codecommit-webhook / verify-sns-signature / TopicArn allowlist / installationId derivation / namespaceDeliveryId
    - platform-github 90 (+11): registry self-register / cloneUrl empty-owner guard
    - cli 62 (+6): `--platform codecommit` happy path / 無効 `--repo` / `recover sync-state` short-circuit / `approvalState` 配線
- [ ] `iam-drift.test.ts` を一度わざと壊す (例: `EXPECTED_PERMISSIONS` から 1 件削除) と spec §8.4 parity の assertion が fail することを確認。
- [ ] `REVIEW_AGENT_SNS_TOPIC_ARNS` 未設定で `/webhook/codecommit` が **403** を返すことを sandbox で確認 (fail-closed 検証)。
- [ ] CodeCommit sandbox で EventBridge → SNS → `/webhook/codecommit` の e2e 動作 (PR open → review post) を 1 件確認。
- [ ] `review-agent review --pr <N> --platform codecommit --repo <name>` を AWS_PROFILE 付きでローカル実行し、review コメントが post されることを確認。


## Closes

このPRが main にマージされると以下のissueが自動closeされます:

- Closes #73 (CodeCommit event receiver)
- Closes #74 (REQUEST_CHANGES → UpdatePullRequestApprovalState)
- Closes #75 (CLI --platform codecommit)
- Closes #76 (CodeCommit eval fixtures + promptfoo)
- Closes #77 (CodeCommit DR runbook)
- Closes #78 (IAM ↔ SDK Command drift test)
- Closes #79 (CodeCommit out-of-scope spec clarifications)
- Closes #80 (VCS abstraction — capabilities + role split + registry)
