### PR TITLE
release: post-v1.2 wave B — #96/#98/#100/#103/#105/#106/#107/#108

### DIFF
--- a/.changeset/issue-105-recover-v1-2.md
+++ b/.changeset/issue-105-recover-v1-2.md
@@ -1,0 +1,35 @@
+---
+'@review-agent/db': minor
+'@review-agent/cli': minor
+---
+
+#105 — `recover review-eval-events` + `recover feedback-history` (GitHub).
+
+Two new CLI subcommands for CodeCommit disaster recovery of v1.2's
+Postgres-canonical tables:
+
+- `review-agent recover review-eval-events --installation-id N --repo owner/repo [--since YYYY-MM-DD] [--dry-run]`
+  reconstructs `review_eval_event` rows by `(installation_id, job_id)`
+  GROUP BY against `cost_ledger`. Financial fields (token/cost/latency)
+  recover via SUM; LLM-output fields (comment_count, severity_dist,
+  dropped_*) are best-effort blanks (locked design decision: those
+  fields are not derivable from `cost_ledger`). Idempotent.
+
+- `review-agent recover feedback-history --installation-id N --repo owner/repo --platform github --candidates-file <path>.jsonl [--dry-run]`
+  takes an operator-supplied JSONL file of `{factType, factText}`
+  candidates and inserts only the rows whose `fact_text` is not
+  already present in `review_history`. Idempotent. `--platform codecommit`
+  rejects with a pointer to issue #110.
+
+New `@review-agent/db` exports:
+
+- `recoverReviewEvalEvents(db, opts)` — pure helper, idempotent insert.
+- `recoverFeedbackHistory(db, opts)` — pure helper, idempotent insert.
+
+CodeCommit `/feedback` re-scrape (CodeCommit adapter pagination of
+`getCommentsForPullRequest`) is carved out as issue #110 to keep #105
+focused on the recovery semantic, not on adding new adapter
+capabilities.
+
+See `docs/operations/codecommit-disaster-recovery.md` § "Step 4.5 —
+Recover v1.2 tables" for the full procedure + locked design decisions.

--- a/.changeset/issue-106-fail-open-metrics.md
+++ b/.changeset/issue-106-fail-open-metrics.md
@@ -1,0 +1,36 @@
+---
+'@review-agent/server': minor
+'@review-agent/runner': minor
+---
+
+#106 — OTel metrics for fail-open events.
+
+Four new counters in `@review-agent/server`'s instrument set so the v1.2
+fail-open paths become alert-able:
+
+- `review_agent_eval_record_errors_total{provider, model}` — `recordEvalEvent`
+  threw (transient DB / OTel exporter failure).
+- `review_agent_feedback_rate_limit_drops_total` — `createFeedbackWriter`
+  dropped a `FeedbackEvent` because the per-job `maxWritesPerJob` cap was
+  reached.
+- `review_agent_review_history_pruned_total` — deleted row count per
+  `startReviewHistoryCleanup` tick (trend monitoring, zero-count ticks
+  suppressed).
+- `review_agent_history_reader_errors_total` — `historyReader` threw inside
+  the runner (the runner still re-raises; the counter fires *before*
+  propagation).
+
+Four default bridge factories — `bridgeEvalRecordErrorsToMetrics`,
+`bridgeFeedbackRateLimitToMetrics`, `bridgePrunedRowsToMetrics`,
+`bridgeHistoryReaderErrorsToMetrics` — operators can pass straight into
+the existing callback hooks (`runReview({onEvalRecordError, onHistoryReaderError})`,
+`createFeedbackWriter({onRateLimit})`, `startReviewHistoryCleanup({onPruned})`).
+
+New `onPruned(count: number)` hook on `ReviewHistoryCleanupDeps` and new
+`onHistoryReaderError(err: unknown)` hook on `RunReviewDeps` (runner). The
+runner re-raises `historyReader` failures unchanged for backwards compatibility;
+the hook only adds observability.
+
+See `docs/architecture/observability.md` → "Fail-open counters" for the
+default wiring and `docs/operations/slo-playbook.md` for the alerting
+thresholds these counters power.

--- a/.changeset/issue-96-fingerprint-marker.md
+++ b/.changeset/issue-96-fingerprint-marker.md
@@ -1,0 +1,24 @@
+---
+'@review-agent/core': minor
+'@review-agent/platform-github': minor
+'@review-agent/platform-codecommit': minor
+'@review-agent/runner': patch
+---
+
+#96 — Embed `<!-- fingerprint:<fp> -->` marker in posted PR comments.
+
+Both VCS adapters (`postReview` in `@review-agent/platform-github` and
+`@review-agent/platform-codecommit`) now append a hidden HTML-comment marker
+carrying the 16-char `fingerprint()` to every inline comment they post. This
+unblocks the marker (a) path of #95's `/feedback` resolver — the operator can
+now reply `/feedback accept` (no argument) on any bot inline comment and the
+worker recovers the fingerprint by reading the parent body.
+
+- `@review-agent/core`: `appendFingerprintMarker(body, fp)` (idempotent
+  writer-side helper) and `extractFingerprintFromComment(body)` (reader-side
+  helper, 8–16 hex tolerant for #95's `fp_prefix` reuse).
+- `@review-agent/runner`: `extractFingerprintMarker` in the feedback
+  fingerprint resolver is now a thin alias for the new core helper; behavior
+  is unchanged for existing callers.
+- Back-compat: `appendFingerprintMarker` is idempotent and does not duplicate
+  markers; pre-#96 posted comments keep working via #95's `fp_prefix` fallback.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -183,6 +183,158 @@ ambitious gets a dedicated `docs/migrations/<topic>.md`.
 
 ---
 
+## From 1.1 → 1.2
+
+v1.2 is a **minor** bump — every change below is backwards-compatible.
+Existing `.review-agent.yml` files keep working byte-for-byte; existing
+`runReview` / `wrapUntrusted` / `postReview` call sites continue to
+compile without arg changes (every new `RunReviewDeps` field is
+optional). The migration adds one new table + one new column, both
+forward-compatible (v1.1 code keeps reading the DB without seeing them).
+
+### 1. DB migration (mandatory before deploying v1.2 code)
+
+Run the migration **before** rolling out the v1.2 code. The migration
+is forward-compatible — v1.1 code keeps working against the migrated
+schema (the v1.1 code does not reference `review_eval_event` or
+`cost_ledger.latency_ms`).
+
+```bash
+pnpm --filter @review-agent/db db:migrate
+```
+
+(or equivalent: `psql -f packages/db/migrations/0003_review_eval_event.sql`
+under the migrations-superuser role).
+
+| Object | Change |
+|---|---|
+| `review_eval_event` (new table) | Per-review metrics — token / cost / latency / `droppedByDedup` / `droppedByFeedback` / `feedbackCount`. RLS-isolated by `installation_id` (spec §7.5). |
+| `cost_ledger.latency_ms` (new nullable column) | Defaults to `NULL` for existing rows; v1.2 writes the per-row latency from the EvalMiddleware. |
+
+Rollback: do **not** run a down-migration. v1.1 code reads from
+neither object, so leaving them in place after a rollback is safe. If
+you genuinely need to remove them, drop the table / column manually
+**after** all v1.2 writers are off.
+
+### 2. New optional `runReview` deps (v1.2 epic #83)
+
+All four are off by default — omit them to preserve v1.1 behaviour.
+
+| Dep | Purpose | Wire when |
+|---|---|---|
+| `evalRecorder` + `evalContext` | Records one `ReviewEvalEvent` per `runReview` into `review_eval_event` (Phase 2 / #91). Fail-open. | You want per-review metrics, judge scores (#101), or feedback analytics. |
+| `historyReader` | Loads `review_history` rows (Phase 4 / #93) for `<learned_facts>` injection + dedup. | You want the feedback loop closed (signal-driven `<learned_facts>`). |
+| `onEvalRecordError` / `onHistoryReaderError` | Fail-open observability — bridge to OTel counters (#106). | You wired OTel and want fail-open errors visible. |
+
+See `docs/architecture/feedback-loop.md` for the wiring diagram. A worked
+example handler will live at `docs/operations/worker-example.md` (#98).
+
+### 3. New optional config keys (`.review-agent.yml` v1)
+
+Added on the same `version: 1` schema — no `version: 2` bump.
+
+| Key | Default | Section |
+|---|---|---|
+| `repo.submodules` | `false` | Set `true` to recurse submodules during sparse-clone workspace provisioning (#89). |
+| `repo.lfs` | `false` | Set `true` to fetch LFS pointers; default keeps `GIT_LFS_SKIP_SMUDGE=1` so reviews never pull binary blobs (#89). |
+| `reviews.path_filters` | `[]` (no skip) | Globs whose matching paths skip review entirely. Zero-cost cap — the agent emits a graceful "skipped" summary instead of calling the LLM (#88). |
+| `reviews.max_files` | unset (no cap) | Integer cap; PRs touching > N files skip review with a graceful summary (#88). |
+| `reviews.max_diff_lines` | unset (no cap) | Integer cap; PRs whose total diff exceeds N lines skip review with a graceful summary (#88). |
+| `privacy.allowed_url_prefixes` | own-repo auto-allow | URL allowlist for LLM-emitted links in `ReviewOutputSchema`. Retry-once-then-graceful-abort on schema violation (#85). |
+| `privacy.deny_paths` | `[]` | Glob list applied to `read_file` / `glob` / `grep` tool dispatch. **Extends** built-in `.env*` / `.ssh/**` / `.aws/credentials` denylist; never relaxes (#86). |
+| `privacy.redact_patterns` | `[]` | Additional gitleaks rules (`custom-N`) applied alongside built-ins on both diff pre-scan and post-LLM redaction (#87). |
+
+`.review-agent.yml` schema dump: regenerate via
+`pnpm --filter @review-agent/config generate-schema` (or pull the latest
+`schema/v1.json`). All v1.1 → v1.2 keys are optional; old files validate
+unchanged.
+
+**v1.1-was-silently-ignored note**: these keys *parsed* in v1.1 (they
+were in the schema) but were not enforced anywhere. v1.2 enforces them.
+Operators who left dead keys in their YAML thinking they were no-ops
+will now see behaviour change — review your existing YAML before
+deploying.
+
+### 4. New CLI subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `review-agent feedback backfill --installation-id N --repo owner/repo [--since YYYY-MM-DD] [--state-file path] [--dry-run]` | Populates `review_history` from historical GitHub reactions for tenants deployed before v1.2 (#99). Resumable via `--state-file`. CodeCommit tenants are out of scope (see #95 / #96). |
+
+### 5. New public exports
+
+The following identifiers are now part of the SemVer-stable public API
+surface:
+
+- `@review-agent/core`: `appendFingerprintMarker`,
+  `extractFingerprintFromComment`, `FeedbackEvent`, `FeedbackKind`,
+  `FEEDBACK_KINDS`, `feedbackKindToFactType`, `ReviewEvalEvent`,
+  `ReviewEvalEventRecorder`.
+- `@review-agent/runner`: `createFeedbackWriter`, `FeedbackWriter`,
+  `FeedbackWriterOptions`, `ReviewHistoryWriter`,
+  `extractFingerprintMarker`, `resolveFingerprint`,
+  `FingerprintResolution`, `FingerprintResolutionInput`.
+- `@review-agent/server`: `startReviewHistoryCleanup`,
+  `ReviewHistoryCleanupDeps`, `handleCodecommitWebhook`,
+  `CodecommitWebhookDeps`, `CodecommitWebhookResult`,
+  `recordFeedbackCommandOutcome`, `FeedbackCommandOutcome`,
+  `parseFeedbackCommand`, `FeedbackCommand`, `FeedbackCommandKind`,
+  `FEEDBACK_COMMAND_PREFIX`, `checkGithubFeedbackAuthz`,
+  `checkCodeCommitFeedbackAuthz`, `FeedbackAuthzResult`,
+  `bridgeEvalRecordErrorsToMetrics`, `bridgeFeedbackRateLimitToMetrics`,
+  `bridgePrunedRowsToMetrics`, `bridgeHistoryReaderErrorsToMetrics`.
+
+### 6. CodeCommit feature parity status
+
+| Phase | Status on CodeCommit |
+|---|---|
+| Phase 1 (eval baseline) | ✅ same as GitHub — `severity_consistency_score` etc. is repo-agnostic. |
+| Phase 2 (per-review metrics) | ✅ — `evalRecorder` runs in the worker regardless of platform. |
+| Phase 3 (feedback writer) | **Partial** — CodeCommit has no reaction API. v1.2 wave A adds `/feedback` comment command (#95 partial: `fp_prefix` path only; #96 enables marker path with no further code change). |
+| Phase 4 (`<learned_facts>` reader) | ✅ — reader is provider-agnostic. Fact density on CodeCommit tenants will lag GitHub until #95 / #96 land in full. |
+
+### 7. Behaviour changes operators may notice
+
+- **Bot inline comments now end with `<!-- fingerprint:<16-hex> -->`** (#96).
+  The marker is a hidden HTML comment so end-user UX is unchanged. It
+  unblocks the `/feedback` (#95) marker-based resolver path.
+- **`/feedback accept|reject|dismiss` comments are recognised on
+  both GitHub and CodeCommit** (#95). Guarded by repo write
+  permission (GitHub) or `REVIEW_AGENT_FEEDBACK_ALLOWLIST` env CSV
+  (CodeCommit, fail-closed when unset). See
+  `docs/security/feedback-command-authz.md`.
+- **`review_history` rows accumulate** if you wire the writer.
+  `startReviewHistoryCleanup` prunes them at the 180-day TTL — wire
+  it alongside `startWorker`. The default tick interval is 1h.
+- **Cost-guard accounting includes tool calls** (already true in v1.1
+  but now visible via `review_eval_event.totalTokens` /
+  `cost_ledger.latency_ms` per-review).
+
+### 8. Baseline / parity / judge enforcement
+
+The new evaluation infrastructure is **informational by default**:
+
+- `severity_consistency_score` in `baseline.json` is `null` until an
+  operator runs `pnpm --filter @review-agent/eval baseline:measure --apply`
+  with a real `ANTHROPIC_API_KEY` (#97).
+- `parity.json` per-provider scores are `null` until #102 populates
+  them.
+- `llm_judge_score` (#101) runs `continue-on-error: true` and is
+  always informational — promotion to an enforcing gate is a separate
+  follow-up.
+
+Skip the measurement steps to keep v1.2 fully passive.
+
+### 9. Detection
+
+`pnpm --filter @review-agent/config generate-schema` will refuse to
+emit if any new v1.2 key has a typo. Beyond that, all additions are
+silent opt-ins — operators who don't wire any of `evalRecorder`,
+`historyReader`, `createFeedbackWriter`, `startReviewHistoryCleanup`
+keep v1.1 runtime behaviour byte-for-byte.
+
+---
+
 ## From 1.0 → 1.1
 
 v1.1 is a **minor** bump — every change below is backwards-compatible.

--- a/docs/architecture/feedback-loop.md
+++ b/docs/architecture/feedback-loop.md
@@ -266,3 +266,9 @@ fine without the feedback row).
   release uses a CSV allowlist; a future iteration can replace it
   with `codecommit:GitPush` simulation against the principal once
   STS / IAM trust paths are settled in production deployments.
+
+## Worked-example handler
+
+For a full end-to-end worker that wires the writer, reader, recorder,
+adapters, OTel bridges, and both cleanup electors together, see
+[`docs/operations/v1-2-worker-example.md`](../operations/v1-2-worker-example.md).

--- a/docs/architecture/feedback-loop.md
+++ b/docs/architecture/feedback-loop.md
@@ -108,7 +108,7 @@ on GitHub for users who prefer typed commands).
 
 | Comment body | `FeedbackKind` | Notes |
 |---|---|---|
-| `/feedback accept` | `thumbs_up` | Reply on a bot comment whose body carries a `<!-- fingerprint:<fp> -->` marker (pending #96). |
+| `/feedback accept` | `thumbs_up` | Reply on a bot comment whose body carries a `<!-- fingerprint:<fp> -->` marker (writer: #96, see [Fingerprint embedding format](#fingerprint-embedding-format)). |
 | `/feedback reject` | `thumbs_down` | Same. Marker-based path. |
 | `/feedback accept <fp_prefix>` | `thumbs_up` | Argument path. `<fp_prefix>` must be `[0-9a-f]{8,}` and prefix-match exactly one entry in `review_state.commentFingerprints`. |
 | `/feedback reject <fp_prefix>` | `thumbs_down` | Same. Argument path. |
@@ -165,13 +165,40 @@ runs in the worker with this precedence:
    `ambiguous_prefix`. 0 matches → `no_match`.
 3. Otherwise → `no_marker_and_no_prefix`.
 
-**Status note (2026-05-19)**: marker embedding (#96) is not yet
-shipped, so the resolver's path (1) is currently inert — no bot
-comment carries the marker. Operators get end-to-end resolution
-**only via path (2) (argument)** until #96 lands. The marker regex
-is implemented and unit-tested today so the day #96 ships a bot
-comment containing the marker, no further code change is needed
-here.
+### Fingerprint embedding format
+
+(Writer: #96 — `packages/platform-github/src/adapter.ts` and
+`packages/platform-codecommit/src/adapter.ts` `postReview`.)
+
+Every inline comment the bot posts has the following marker appended
+to its body so the (1) resolver path above can recover the fingerprint
+without a DB lookup:
+
+```
+<finding body>
+
+<!-- fingerprint:<16-hex> -->
+```
+
+- `<16-hex>` is the 16-character `fingerprint()` output from
+  `packages/core/src/fingerprint.ts`. The full value is embedded so
+  the resolver's exact-match path against
+  `review_state.commentFingerprints` succeeds without prefix logic.
+- The marker is added via `appendFingerprintMarker()` from
+  `@review-agent/core` — both adapters use the same helper to keep the
+  format identical (regex `/<!--\s*fingerprint:([0-9a-f]{8,16})\s*-->/i`
+  in `extractFingerprintFromComment`).
+- `appendFingerprintMarker` is **idempotent** — passing the same
+  fingerprint twice does not produce duplicate markers. This makes
+  re-posts safe.
+- The marker is rendered as a hidden HTML comment on both platforms
+  (GitHub Markdown and CodeCommit Markdown both swallow it on render),
+  so the end-user view is unchanged.
+
+**Back-compat**: posted comments created **before** #96 shipped have
+no marker. `/feedback` on those comments falls back to path (2)
+(`<fp_prefix>` argument) automatically — that is the v1.2 #95 design.
+Operators do not need to repost the historical comments.
 
 ### Receiver-side flow (extended)
 

--- a/docs/architecture/learned-facts.md
+++ b/docs/architecture/learned-facts.md
@@ -87,4 +87,10 @@ operator answer:
   output, or is the dedup backstop carrying the win alone?
 
 A SQL recipe lives in `docs/eval/` (alongside the existing
-baseline-measurement workflow).
+baseline-measurement workflow); the operator-facing analytic recipes
+are in
+[`docs/operations/review-eval-event-playbook.md`](../operations/review-eval-event-playbook.md).
+
+A full Lambda / Fargate worker that wires the history reader into
+`runReview` alongside the eval recorder and feedback writer is at
+[`docs/operations/v1-2-worker-example.md`](../operations/v1-2-worker-example.md).

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -113,6 +113,61 @@ The instrument set is a singleton; the first call lazily binds against the
 global meter provider so it works whether or not telemetry is active.
 Unrecorded labels are dropped at export time by the backend.
 
+### Fail-open counters (v1.2 #106)
+
+The v1.2 wave added four counters that observe failures the runner / worker
+**deliberately swallow** (or expose only via callback) so the user-visible
+review still completes. Wire them via the default bridges exported from
+`@review-agent/server` — operators can wrap a bridge to add extra side
+effects (logging, additional counter) without rebuilding the OTel wiring.
+
+| Counter | Source | Bridge |
+|---|---|---|
+| `review_agent_eval_record_errors_total{provider, model}` | `recordEvalEvent` threw inside the eval middleware | `bridgeEvalRecordErrorsToMetrics({ provider, model })` → pass to `runReview({ onEvalRecordError })` |
+| `review_agent_feedback_rate_limit_drops_total` | `createFeedbackWriter` dropped an event because `maxWritesPerJob` was reached | `bridgeFeedbackRateLimitToMetrics()` → pass to `createFeedbackWriter({ onRateLimit })` |
+| `review_agent_review_history_pruned_total` | `startReviewHistoryCleanup` deleted N expired `review_history` rows on this tick (zero-count ticks suppressed) | `bridgePrunedRowsToMetrics()` → pass to `startReviewHistoryCleanup({ onPruned })` |
+| `review_agent_history_reader_errors_total` | `historyReader` threw inside the runner (the runner **does** re-raise — this fires *before* the throw propagates) | `bridgeHistoryReaderErrorsToMetrics()` → pass to `runReview({ onHistoryReaderError })` |
+
+Example wiring:
+
+```ts
+import {
+  bridgeEvalRecordErrorsToMetrics,
+  bridgeFeedbackRateLimitToMetrics,
+  bridgeHistoryReaderErrorsToMetrics,
+  bridgePrunedRowsToMetrics,
+  startReviewHistoryCleanup,
+} from '@review-agent/server';
+import { createFeedbackWriter, runReview } from '@review-agent/runner';
+
+// Worker boot
+const cleanup = startReviewHistoryCleanup({
+  db,
+  onPruned: bridgePrunedRowsToMetrics(),
+});
+
+// Per-job
+const feedback = createFeedbackWriter({
+  writer,
+  onRateLimit: bridgeFeedbackRateLimitToMetrics(),
+});
+await runReview(job, provider, {
+  evalRecorder,
+  historyReader,
+  onEvalRecordError: bridgeEvalRecordErrorsToMetrics({
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+  }),
+  onHistoryReaderError: bridgeHistoryReaderErrorsToMetrics(),
+});
+```
+
+These metrics feed the alert thresholds in
+[`docs/operations/slo-playbook.md`](../operations/slo-playbook.md) — the
+playbook's "Cost-guard `kill` 発火", "Feedback rate-limit drop", and
+"Dropped by feedback" rows correspond to these counters (the playbook was
+written speculatively against the planned metric names).
+
 ## Local development
 
 For local end-to-end debugging, run a Jaeger or Grafana Tempo container

--- a/docs/architecture/review-eval-event.md
+++ b/docs/architecture/review-eval-event.md
@@ -81,3 +81,11 @@ Schema and migration live in `@review-agent/core/db`:
 - `packages/core/src/db/migrations/0003_review_eval_event.sql` — DDL + RLS policy + `cost_ledger.latency_ms` column.
 
 Run `pnpm --filter @review-agent/db db:migrate` to apply.
+
+## Operator SQL playbook
+
+For canonical SELECT queries — per-provider averages, severity shifts,
+`dropped_by_feedback` ranking, dedup ratio trend, `abort_reason`
+distribution, per-call/per-review latency JOIN, `confidence_dist`
+calibration — see
+[`docs/operations/review-eval-event-playbook.md`](../operations/review-eval-event-playbook.md).

--- a/docs/architecture/review-eval-event.md
+++ b/docs/architecture/review-eval-event.md
@@ -89,3 +89,9 @@ For canonical SELECT queries — per-provider averages, severity shifts,
 distribution, per-call/per-review latency JOIN, `confidence_dist`
 calibration — see
 [`docs/operations/review-eval-event-playbook.md`](../operations/review-eval-event-playbook.md).
+
+## Worked-example handler
+
+A full Lambda / Fargate worker that constructs `evalRecorder` +
+`evalContext` and threads them through `withTenant` + `runReview` is at
+[`docs/operations/v1-2-worker-example.md`](../operations/v1-2-worker-example.md).

--- a/docs/operations/codecommit-disaster-recovery.md
+++ b/docs/operations/codecommit-disaster-recovery.md
@@ -207,6 +207,77 @@ re-review, the dedup pass will hit *existing* CodeCommit comments
 already there. The cost spend is still incurred for the LLM call — the
 saving is only on visible duplicate comments.
 
+### Step 4.5 — Recover v1.2 tables (v1.2 #105)
+
+In addition to `review_state`, the v1.2 wave added three Postgres
+tables that the runner / writer / reader fan-out depends on:
+`review_eval_event` (per-review metrics, #91), `cost_ledger.latency_ms`
+(per-call latency column, #91), and `review_history` (feedback signals,
+#92). After a Postgres restore + manual re-review pass (Step 4), you
+typically have:
+
+- `cost_ledger` rows for every re-reviewed PR (the runner writes these
+  unconditionally).
+- `review_state` rows in good shape from Step 4.
+- `review_eval_event` empty, because manual re-review goes through the
+  current code which records new rows; older pre-incident rows are
+  gone.
+- `review_history` empty, because feedback signals are not re-derivable
+  from CodeCommit (no reaction API).
+
+Two new subcommands fill the v1.2 gap:
+
+```bash
+# 1. Reconstruct review_eval_event rows from cost_ledger aggregation.
+#    Idempotent — re-running with the same args inserts nothing on the
+#    second pass. The recovered rows have aggregate financial fields
+#    (latency_ms / cost_usd / tokens_in/out from SUM) but the
+#    LLM-output fields (comment_count, severity_dist, dropped_*) are
+#    set to zero / empty JSONB because cost_ledger does not carry them.
+#    Per-PR fields (pr_number, head_sha) are placeholders.
+DATABASE_URL=... review-agent recover review-eval-events \
+  --installation-id <id> \
+  --repo <owner/repo> \
+  [--since 2026-05-01] \
+  [--dry-run]
+
+# 2. Recover review_history from an operator-supplied JSONL file. The
+#    file format is one JSON object per line:
+#      { "factType": "rejected_finding", "factText": "[fp:abc] ..." }
+#    Source the file from prior `feedback backfill` exports, manual
+#    SQL extracts, or log scraping. Lines starting with `//` are
+#    ignored so operators can annotate.
+#
+#    --platform codecommit is REJECTED in v1.2 (tracked as #110).
+#    For CodeCommit /feedback re-scrape, follow #110 once it ships.
+DATABASE_URL=... review-agent recover feedback-history \
+  --installation-id <id> \
+  --repo <owner/repo> \
+  --platform github \
+  --candidates-file ./feedback-candidates.jsonl \
+  [--dry-run]
+```
+
+Both commands run under `withTenant` so RLS scopes the read + insert
+to the matching `installation_id`. Both are idempotent: `review-eval-
+events` checks `(installation_id, job_id)` existence; `feedback-history`
+checks `fact_text` equality (full string match, which the
+`[fp:<fingerprint>]` prefix makes deterministic).
+
+**Locked design decisions** (issue #105):
+
+- **Recovery source for `review_eval_event`** — `cost_ledger` GROUP BY
+  `(installation_id, job_id)`. Financial fields reconstructed via SUM;
+  LLM-output fields are best-effort blanks.
+- **Recovery source for `review_history`** — operator-supplied JSONL.
+  The CLI deliberately does NOT pull from GitHub directly to keep
+  recovery decoupled from a working installation token; pair the
+  JSONL prep step with whatever export the operator has on hand
+  (Phase 3 logs, prior `feedback backfill --dry-run`).
+- **CodeCommit `/feedback` re-scrape** — out of scope for #105;
+  tracked as #110 (CodeCommit adapter does not yet implement PR
+  comment pagination).
+
 ### Step 5 — Resume normal operation
 
 Restart the worker pool, monitor the cost-ledger for the expected

--- a/docs/operations/review-eval-event-playbook.md
+++ b/docs/operations/review-eval-event-playbook.md
@@ -1,0 +1,266 @@
+# `review_eval_event` SQL playbook
+
+This is the ops-side companion to
+[`docs/architecture/review-eval-event.md`](../architecture/review-eval-event.md).
+The architecture doc explains the table and how the runner writes it; this
+playbook gives the **canonical queries** for reading it — what to ask after
+a prompt change, after a provider swap, or during a monthly review retro.
+
+## Scope and connection setup
+
+All queries below are written **for the `appRole` connection** with the
+tenant pre-set via `withTenant(installationId, ...)` (`@review-agent/db`).
+From a `psql` shell:
+
+```sql
+SET LOCAL ROLE app_role;
+SET LOCAL app.current_tenant = '12345';  -- installation_id
+```
+
+Run them under the `migrations` / superuser role only when you genuinely
+need cross-tenant aggregates — flagged per query below. The RLS policy
+on `review_eval_event` is `installation_id::text =
+current_setting('app.current_tenant', true)`; under `appRole` a missing
+or mismatched setting silently returns zero rows (no error). Verify
+expected row counts before drawing conclusions.
+
+> The same applies to JOINs against `cost_ledger`: that table has the
+> same RLS policy, so both legs of a join either resolve under the same
+> tenant or both return empty.
+
+Index reminders (see `0003_review_eval_event.sql`):
+
+- `review_eval_event_installation_repo_idx (installation_id, repo)`
+- `review_eval_event_created_at_idx (created_at)`
+- `review_eval_event_job_idx (installation_id, job_id)`
+
+The (`installation_id`, `repo`) index is the workhorse — most queries
+below filter on those two columns first.
+
+## Recipes
+
+### 1. Per-provider average latency / cost / comment count (last 30 days)
+
+Use after a model swap to verify the new provider is not silently
+worse on cost or latency.
+
+```sql
+SELECT
+  provider,
+  model,
+  count(*)                   AS reviews,
+  round(avg(latency_ms)::numeric, 0)  AS avg_latency_ms,
+  round(avg(cost_usd)::numeric, 4)    AS avg_cost_usd,
+  round(avg(comment_count)::numeric, 1) AS avg_comments,
+  percentile_cont(0.5)  WITHIN GROUP (ORDER BY latency_ms) AS p50_latency_ms,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) AS p95_latency_ms
+FROM review_eval_event
+WHERE created_at >= now() - interval '30 days'
+GROUP BY provider, model
+ORDER BY reviews DESC;
+```
+
+- Uses `review_eval_event_created_at_idx` for the date filter.
+- `p95_latency_ms` matches the `Review latency` SLO in
+  [`slo-playbook.md`](./slo-playbook.md); the alert threshold is `> 90s`.
+
+### 2. Severity distribution shift, week over week
+
+Use this to detect prompt regressions where the rubric stops producing
+critical findings (or starts producing too many).
+
+```sql
+SELECT
+  date_trunc('week', created_at) AS week,
+  sum((severity_dist->>'critical')::int) AS critical,
+  sum((severity_dist->>'major')::int)    AS major,
+  sum((severity_dist->>'minor')::int)    AS minor,
+  sum((severity_dist->>'info')::int)     AS info,
+  count(*) AS reviews
+FROM review_eval_event
+WHERE created_at >= now() - interval '12 weeks'
+GROUP BY week
+ORDER BY week;
+```
+
+- `severity_dist` is JSONB; coerce to int via `->>` then cast.
+- Look for sudden shifts in either direction after a `BASE_SYSTEM_PROMPT`
+  edit. A week with 0 `critical` after months of nonzero is the
+  prompt-regression smell test.
+
+### 3. `dropped_by_feedback` top-N repos (last 14 days)
+
+Where the v1.2 epic #83 Phase 4 (#93) feedback loop is most active —
+high counts mean the bot is being told "stop saying this" frequently
+on that repo, which is either (a) successful learning, or (b) a noisy
+rule the operator should sharpen.
+
+```sql
+SELECT
+  repo,
+  sum(dropped_by_feedback) AS dropped_total,
+  count(*) AS reviews,
+  round(avg(dropped_by_feedback)::numeric, 2) AS avg_dropped_per_review
+FROM review_eval_event
+WHERE created_at >= now() - interval '14 days'
+  AND dropped_by_feedback > 0
+GROUP BY repo
+ORDER BY dropped_total DESC
+LIMIT 10;
+```
+
+- The `WHERE dropped_by_feedback > 0` filter lets the planner skip the
+  zero-rows that dominate the table when Phase 4 is still ramping up.
+
+### 4. Dedup effectiveness — `dropped_duplicates` ratio
+
+Incremental review (#19) and fingerprint dedup (#9) should suppress
+re-flags of the same finding across multiple `synchronize` events. A
+falling ratio after a prompt change can mean the LLM is now emitting
+phrasings that bypass the same-line dedup.
+
+```sql
+SELECT
+  date_trunc('day', created_at) AS day,
+  sum(comment_count)        AS posted,
+  sum(dropped_duplicates)   AS deduped,
+  round(
+    sum(dropped_duplicates)::numeric
+      / nullif(sum(comment_count) + sum(dropped_duplicates), 0),
+    3
+  ) AS dedup_ratio
+FROM review_eval_event
+WHERE created_at >= now() - interval '14 days'
+GROUP BY day
+ORDER BY day;
+```
+
+- `nullif(... , 0)` avoids `division by zero` on quiet days.
+- Plot the ratio over time; a falling line is the early signal.
+
+### 5. `abort_reason` distribution
+
+`abort_reason` is non-null when the agent loop gracefully aborted
+(`url_allowlist`, `schema_violation`, `max_files_exceeded`,
+`max_diff_lines_exceeded`). Use to size the caps in
+`.review-agent.yml`.
+
+```sql
+SELECT
+  coalesce(abort_reason, 'ok') AS reason,
+  count(*) AS occurrences,
+  round(100.0 * count(*) / sum(count(*)) OVER (), 2) AS pct_of_reviews
+FROM review_eval_event
+WHERE created_at >= now() - interval '30 days'
+GROUP BY abort_reason
+ORDER BY occurrences DESC;
+```
+
+- A spike in `max_files_exceeded` is your cue that
+  `reviews.max_files` is too tight (or your repo really does have
+  monster PRs).
+- A spike in `schema_violation` after a prompt edit means the model is
+  no longer reliably emitting the strict-JSON shape; consider
+  rolling back the prompt.
+
+### 6. Per-call vs per-review latency — JOIN to `cost_ledger`
+
+`review_eval_event.latency_ms` is the **wall-clock** time the runner
+spent inside `runReview` (gitleaks + LLM + dedup + scan). `cost_ledger`
+has per-LLM-call rows with their own `latency_ms`. When the runner
+makes one main call + N injection-detect calls + retries, the per-call
+sum can lag per-review wall-clock by the middleware overhead. A wide
+gap = something inside the runner outside the LLM calls is slow.
+
+```sql
+WITH per_review_calls AS (
+  SELECT
+    job_id,
+    sum(latency_ms) AS sum_call_latency_ms,
+    sum(cost_usd)   AS sum_call_cost_usd,
+    count(*)        AS llm_calls
+  FROM cost_ledger
+  WHERE created_at >= now() - interval '7 days'
+  GROUP BY job_id
+)
+SELECT
+  r.job_id,
+  r.repo,
+  r.provider,
+  r.latency_ms        AS review_latency_ms,
+  c.sum_call_latency_ms,
+  r.latency_ms - c.sum_call_latency_ms AS runner_overhead_ms,
+  c.llm_calls
+FROM review_eval_event r
+JOIN per_review_calls c USING (job_id)
+WHERE r.created_at >= now() - interval '7 days'
+ORDER BY runner_overhead_ms DESC
+LIMIT 20;
+```
+
+- Both tables are RLS-scoped on `installation_id`, so the join stays
+  inside the tenant.
+- Sort by `runner_overhead_ms DESC` to find the worst non-LLM
+  contributors (gitleaks regressions, slow `read_file` tool calls,
+  middleware bugs).
+
+### 7. Confidence distribution — calibrating `reviews.min_confidence`
+
+Before raising the floor (e.g. `low → medium`), check how many
+findings you would actually drop.
+
+```sql
+SELECT
+  sum((confidence_dist->>'high')::int)   AS high,
+  sum((confidence_dist->>'medium')::int) AS medium,
+  sum((confidence_dist->>'low')::int)    AS low,
+  round(
+    100.0 * sum((confidence_dist->>'low')::int)
+          / nullif(sum((confidence_dist->>'high')::int)
+                  + sum((confidence_dist->>'medium')::int)
+                  + sum((confidence_dist->>'low')::int), 0),
+    2
+  ) AS pct_low
+FROM review_eval_event
+WHERE created_at >= now() - interval '30 days';
+```
+
+- If `pct_low` is small (< 5%), raising `min_confidence: medium` is
+  unlikely to change reviewer experience meaningfully.
+- Comments emitted without a `confidence` field are counted under
+  `high` per the legacy default — the column never decreases when the
+  model omits the field.
+
+## Cross-tenant queries (run as `migrations` / superuser)
+
+These return zero rows under `appRole` because of RLS. Use sparingly —
+single-tenant queries above are the default.
+
+### Fleet-wide median latency per provider
+
+```sql
+SET ROLE migrations_admin; -- or whichever role bypasses RLS
+
+SELECT
+  provider,
+  model,
+  percentile_cont(0.5)  WITHIN GROUP (ORDER BY latency_ms) AS p50,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) AS p95,
+  count(*) AS reviews
+FROM review_eval_event
+WHERE created_at >= now() - interval '7 days'
+GROUP BY provider, model
+ORDER BY reviews DESC;
+
+RESET ROLE;
+```
+
+Always pair `SET ROLE` with `RESET ROLE` so a forgotten cross-tenant
+connection does not leak into your next query.
+
+## Out of scope
+
+The architecture doc lists the deferred items (Grafana / Looker
+dashboards, BI integrations, pairwise judge correlation). This playbook
+sticks to single-SQL recipes that operators can paste into `psql` or a
+generic SQL UI.

--- a/docs/operations/v1-2-worker-example.md
+++ b/docs/operations/v1-2-worker-example.md
@@ -1,0 +1,281 @@
+# Worked-example: Server-mode worker for v1.2
+
+End-to-end TypeScript reference for assembling a Lambda / Fargate
+worker against the v1.2 stack — `runReview` with the eval recorder,
+history reader, feedback writer, both cleanup electors, and the OTel
+bridges. Each layer has its own architecture doc; this example is the
+**connecting tissue** so a first-time operator can read one page and
+know the wiring order.
+
+The example is shaped for AWS Lambda + SQS but the same code runs
+under Fargate / a long-lived process — just replace
+`createSqsLambdaHandler` with `startWorker` and keep the rest.
+
+## Module map
+
+```
+@review-agent/server   — receive (webhook), worker bootstrap, OTel bridges
+@review-agent/runner   — runReview, agent loop, createFeedbackWriter
+@review-agent/db       — createDbClient, withTenant, recorders/writers
+@review-agent/runner   — fingerprint resolver (#95 / #96)
+@review-agent/platform-github / @review-agent/platform-codecommit — adapters
+```
+
+## Environment
+
+```
+DATABASE_URL                 postgres URL (tenant connection — use the appRole)
+DATABASE_MIGRATIONS_URL      optional, only for migrations (RLS-bypass role)
+REVIEW_AGENT_BOT_LOGIN       e.g. 'review-agent[bot]' — used by feedback backfill
+REVIEW_AGENT_FEEDBACK_ALLOWLIST   CSV of CodeCommit IAM principals (#95)
+GITHUB_APP_ID                GitHub App credentials for installation tokens
+GITHUB_APP_PRIVATE_KEY       (PEM, base64-encoded if going through SSM)
+ANTHROPIC_API_KEY            primary provider; rotate via spec §15.
+OTEL_EXPORTER_OTLP_ENDPOINT  OTLP collector for spans + metrics
+SQS_QUEUE_URL                review job queue
+SNS_TOPIC_ARNS_ALLOWLIST     CSV — CodeCommit notification topics
+```
+
+## Boot sequence
+
+The worker has three responsibilities:
+
+1. **Process review jobs** (`dequeue` → `runReview` → adapter `postReview`).
+2. **Process feedback commands** (`dequeue` of a `kind: 'feedback'` job
+   → `createFeedbackWriter.record`). The receiver classifies and
+   enqueues; the worker performs the DB write under RLS.
+3. **Periodic prune** (`startIdempotencyCleanup` + `startReviewHistoryCleanup`).
+
+Run all three from one process so the advisory-lock leader election
+works across the fleet automatically.
+
+```ts
+// worker/main.ts
+import { Anthropic } from '@anthropic-ai/sdk';
+import {
+  bridgeEvalRecordErrorsToMetrics,
+  bridgeFeedbackRateLimitToMetrics,
+  bridgeHistoryReaderErrorsToMetrics,
+  bridgePrunedRowsToMetrics,
+  createSqsLambdaHandler,
+  startReviewHistoryCleanup,
+  startTelemetry,
+} from '@review-agent/server';
+import {
+  createDbClient,
+  createReviewEvalEventRecorder,
+  createReviewHistoryWriter,
+  loadRecentReviewHistory,
+  withTenant,
+} from '@review-agent/db';
+import { createFeedbackWriter, runReview } from '@review-agent/runner';
+import { createGithubVCS } from '@review-agent/platform-github';
+import { createAnthropicLlmProvider } from '@review-agent/llm';
+
+// One-time setup at module load. Lambda freezes the container between
+// invocations so this runs once per cold-start and is cached.
+const telemetry = startTelemetry({ exporter: 'otlp' });
+const db = createDbClient({ url: process.env.DATABASE_URL ?? '' });
+const evalRecorder = createReviewEvalEventRecorder(db);
+const reviewHistoryWriter = createReviewHistoryWriter(db);
+
+// Background cleanup electors. Survive Lambda freeze/thaw because the
+// elector is itself stateless — each tick re-acquires the advisory
+// lock. On Fargate this runs continuously.
+startReviewHistoryCleanup({
+  db,
+  onPruned: bridgePrunedRowsToMetrics(),
+});
+// startIdempotencyCleanup is bootstrapped inside startWorker for
+// long-lived processes, or you can call it directly for Lambda.
+
+export const handler = createSqsLambdaHandler({
+  queueUrl: process.env.SQS_QUEUE_URL ?? '',
+  jobHandler: async (job) => {
+    // Per-job tenant scope. Every DB read / write inside withTenant
+    // sees `app.current_tenant = installationId`, which the RLS
+    // policies on cost_ledger / review_history / review_eval_event
+    // require.
+    await withTenant(db, job.installationId, async () => {
+      if (job.kind === 'review') {
+        await handleReview(job);
+        return;
+      }
+      if (job.kind === 'feedback') {
+        await handleFeedback(job);
+        return;
+      }
+      throw new Error(`unknown job kind: ${String(job satisfies never)}`);
+    });
+  },
+  stopSignal: telemetry.stopSignal,
+});
+
+async function handleReview(job: ReviewJob): Promise<void> {
+  const vcs = createGithubVCS({
+    appAuth: githubAppAuth(job.installationId),
+  });
+  const provider = createAnthropicLlmProvider({
+    apiKey: process.env.ANTHROPIC_API_KEY ?? '',
+    model: 'claude-sonnet-4-6',
+  });
+
+  const pr = await vcs.getPR(job.prRef);
+  const diff = await vcs.getDiff(job.prRef);
+
+  // Phase 4 history reader. The runner calls this once per review and
+  // splits the rows into <learned_facts> + rejectedFingerprints for
+  // the dedup middleware.
+  const historyReader = async (q: {
+    installationId: bigint;
+    repo: string;
+    limit: number;
+  }) => loadRecentReviewHistory(db, q);
+
+  const result = await runReview(
+    {
+      jobId: job.jobId,
+      prRepo: job.prRef,
+      diff,
+      pr,
+      privacy: job.privacy,
+      // ... reviews / repo / skills fields
+    },
+    provider,
+    {
+      evalRecorder,
+      evalContext: {
+        installationId: job.installationId,
+        prNumber: job.prRef.number,
+        headSha: diff.headSha,
+      },
+      historyReader,
+      onEvalRecordError: bridgeEvalRecordErrorsToMetrics({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+      }),
+      onHistoryReaderError: bridgeHistoryReaderErrorsToMetrics(),
+    },
+  );
+
+  await vcs.postReview(job.prRef, {
+    summary: result.summary,
+    comments: result.comments,
+    state: result.state,
+    event: result.event,
+  });
+}
+
+async function handleFeedback(job: FeedbackJob): Promise<void> {
+  // The receiver already resolved the fingerprint (via marker or
+  // <fp_prefix>) and classified the FeedbackKind. The worker just
+  // persists.
+  const writer = createFeedbackWriter({
+    writer: async (input) => {
+      await reviewHistoryWriter(input);
+    },
+    redactPatterns: job.privacy?.redactPatterns,
+    onRateLimit: bridgeFeedbackRateLimitToMetrics(),
+  });
+
+  await writer.record({
+    installationId: job.installationId,
+    repo: job.repo,
+    kind: job.kind,
+    fingerprint: job.fingerprint,
+    factText: job.commentText,
+  });
+}
+```
+
+## Receiver side (webhook → enqueue)
+
+The webhook handler runs at a different lifecycle (API Gateway-fronted
+Lambda or Hono server). It does **no** DB writes itself — every
+mutation is deferred to the worker through SQS. The receiver's only
+jobs are: verify signature → classify (`review` vs `feedback`) →
+enqueue.
+
+```ts
+// receiver/main.ts
+import { createApp, checkGithubFeedbackAuthz } from '@review-agent/server';
+import { createSqsQueueClient } from '@review-agent/server';
+import { Octokit } from '@octokit/rest';
+
+const queue = createSqsQueueClient({ url: process.env.SQS_QUEUE_URL ?? '' });
+
+const app = createApp({
+  queue,
+  // GitHub permission check for /feedback commands (#95). When unset
+  // the receiver fails-closed on every /feedback (good default).
+  checkGithubFeedbackAuthz: async (input) => {
+    const octokit = await octokitForInstallation(input.owner, input.repo);
+    return checkGithubFeedbackAuthz({
+      octokit,
+      owner: input.owner,
+      repo: input.repo,
+      username: input.username,
+    });
+  },
+  // CodeCommit /feedback allowlist (#95). Receiver reads this CSV;
+  // worker does not re-check.
+  codecommitFeedbackAllowlistEnv: process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST,
+  allowedSnsTopicArns: (process.env.SNS_TOPIC_ARNS_ALLOWLIST ?? '').split(','),
+});
+
+export const handler = app.fetch;
+```
+
+## SQS message shapes
+
+The same queue carries both job kinds. The worker discriminates on
+`kind`. Validate at the queue boundary with the existing Zod
+`JobMessageSchema` (`@review-agent/core`) — the schema's discriminated
+union covers `kind: 'review' | 'feedback' | 'codecommit-mirror' …`.
+
+## Operational checklist
+
+- [ ] Run the v1.2 migration (`0003_review_eval_event.sql`) before
+      rolling out the worker. The migration is forward-compatible —
+      v1.1 code keeps working against the new schema (UPGRADING.md
+      "From 1.1 → 1.2" §1).
+- [ ] Confirm `DATABASE_URL` uses the `app_role` connection, not the
+      migrations role — otherwise RLS does not engage and the worker
+      will silently see other tenants' data.
+- [ ] OTel exporter receives `review_agent_eval_record_errors_total`,
+      `review_agent_feedback_rate_limit_drops_total`,
+      `review_agent_review_history_pruned_total`,
+      `review_agent_history_reader_errors_total`. Wire alerts per
+      [`slo-playbook.md`](./slo-playbook.md).
+- [ ] `startReviewHistoryCleanup` is bootstrapped on at least one
+      worker (the advisory-lock leader election permits N≥2 workers
+      to run safely; only one prunes per tick).
+- [ ] CodeCommit tenants: set `REVIEW_AGENT_FEEDBACK_ALLOWLIST`
+      explicitly. Empty / unset = every `/feedback` denied (fail-closed,
+      see `docs/security/feedback-command-authz.md`).
+- [ ] Anthropic ZDR + spend caps configured per `review-agent setup
+      workspace` (v1.0 #50).
+
+## Where this fits in the docs
+
+- [`docs/architecture/review-eval-event.md`](../architecture/review-eval-event.md)
+  — schema + recorder semantics (Phase 2).
+- [`docs/architecture/feedback-loop.md`](../architecture/feedback-loop.md)
+  — signal collection, `/feedback` command, fingerprint resolution
+  (Phase 3 / #95 / #96).
+- [`docs/architecture/learned-facts.md`](../architecture/learned-facts.md)
+  — Phase 4 reader contract.
+- [`docs/architecture/observability.md`](../architecture/observability.md)
+  — OTel bridges (#106).
+- [`docs/operations/slo-playbook.md`](./slo-playbook.md)
+  — alert thresholds.
+- [`docs/operations/review-eval-event-playbook.md`](./review-eval-event-playbook.md)
+  — SQL recipes for analysing the table this worker writes.
+
+## Out of scope
+
+- Production Terraform / IaC for the Lambda + SQS topology lives in
+  [`examples/aws-lambda-terraform/`](../../examples/aws-lambda-terraform).
+  This doc focuses on the **code assembly**.
+- Multi-region failover semantics, CodeCommit mirror reconciliation
+  (#105) — call out a follow-up issue rather than inlining here.

--- a/packages/cli/src/commands/recover.test.ts
+++ b/packages/cli/src/commands/recover.test.ts
@@ -1,6 +1,10 @@
 import type { ReviewState, VCS } from '@review-agent/core';
 import { describe, expect, it, vi } from 'vitest';
-import { recoverSyncStateCommand } from './recover.js';
+import {
+  recoverFeedbackHistoryCommand,
+  recoverReviewEvalEventsCommand,
+  recoverSyncStateCommand,
+} from './recover.js';
 
 function recordingIo() {
   const out: string[] = [];
@@ -171,5 +175,152 @@ describe('recoverSyncStateCommand', () => {
     });
     expect(result).toEqual({ status: 'ok', recovered: 0, missing: [] });
     expect(io.out.join('')).toContain('Found 0 open PR(s)');
+  });
+});
+
+describe('recoverReviewEvalEventsCommand (#105)', () => {
+  it('errors out without DATABASE_URL', async () => {
+    const io = recordingIo();
+    const result = await recoverReviewEvalEventsCommand(io, {
+      repo: 'almondoo/review-agent',
+      installationId: 1n,
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(result).toEqual({
+      status: 'ok',
+      candidates: 0,
+      recovered: 0,
+      skippedExisting: 0,
+    });
+    expect(io.err.join('')).toContain('DATABASE_URL is required');
+  });
+
+  it('reports recovery counts from the createDb seam (zero candidates path)', async () => {
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    // Stub the db.select(...).from(...).where(...).groupBy(...) chain so
+    // candidateRows resolves to []. The helper's early-return at
+    // candidates=0 then exercises the format + close path without
+    // needing the full Drizzle chain mocked.
+    const groupBy = vi.fn(async () => []);
+    const where = vi.fn(() => ({ groupBy }));
+    const from = vi.fn(() => ({ where }));
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: vi.fn(() => ({ from })),
+      insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+    };
+
+    const result = await recoverReviewEvalEventsCommand(io, {
+      repo: 'almondoo/review-agent',
+      installationId: 42n,
+      env: { DATABASE_URL: 'postgres://stub' } as NodeJS.ProcessEnv,
+      dryRun: true,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client shape
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    expect(result).toEqual({
+      status: 'ok',
+      candidates: 0,
+      recovered: 0,
+      skippedExisting: 0,
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(io.out.join('')).toContain('review-eval-events recovery for installation=42');
+    expect(io.out.join('')).toContain('dry-run; no inserts');
+  });
+});
+
+describe('recoverFeedbackHistoryCommand (#105)', () => {
+  it('rejects --platform codecommit with reference to #110', async () => {
+    const io = recordingIo();
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'almondoo/review-agent',
+      installationId: 1n,
+      env: { DATABASE_URL: 'postgres://x' } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      candidatesFile: '/tmp/x.jsonl',
+    });
+    expect(result).toEqual({
+      status: 'ok',
+      candidates: 0,
+      recovered: 0,
+      skippedExisting: 0,
+    });
+    expect(io.err.join('')).toContain('not yet supported');
+    expect(io.err.join('')).toContain('#110');
+  });
+
+  it('errors out without DATABASE_URL', async () => {
+    const io = recordingIo();
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'almondoo/review-agent',
+      installationId: 1n,
+      env: {} as NodeJS.ProcessEnv,
+      platform: 'github',
+      candidatesFile: '/tmp/x.jsonl',
+    });
+    expect(result.status).toBe('ok');
+    expect(io.err.join('')).toContain('DATABASE_URL is required');
+  });
+
+  it('parses JSONL candidates and reports counts (dry-run uses the createDb seam)', async () => {
+    const io = recordingIo();
+    const candidatesJsonl =
+      '{"factType":"rejected_finding","factText":"[fp:abc] one"}\n' +
+      '// comment line — operator note\n' +
+      '\n' +
+      '{"factType":"accepted_pattern","factText":"[fp:def] two"}\n';
+    const close = vi.fn(async () => undefined);
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'almondoo/review-agent',
+      installationId: 7n,
+      env: { DATABASE_URL: 'postgres://x' } as NodeJS.ProcessEnv,
+      platform: 'github',
+      candidatesFile: '/tmp/x.jsonl',
+      dryRun: true,
+      readFile: async () => candidatesJsonl,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client shape
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    expect(result.status).toBe('ok');
+    // 2 candidates parsed (the comment + blank line are skipped).
+    expect(result.candidates).toBe(2);
+    // dry-run reports skippedExisting = candidates - fresh; with no
+    // existing rows we keep all as fresh-but-not-inserted.
+    expect(result.recovered).toBe(0);
+    expect(io.out.join('')).toContain('candidates=2');
+    expect(io.out.join('')).toContain('dry-run; no inserts');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed JSONL with a clear error', async () => {
+    const io = recordingIo();
+    await expect(() =>
+      recoverFeedbackHistoryCommand(io, {
+        repo: 'almondoo/review-agent',
+        installationId: 7n,
+        env: { DATABASE_URL: 'postgres://x' } as NodeJS.ProcessEnv,
+        platform: 'github',
+        candidatesFile: '/tmp/bad.jsonl',
+        readFile: async () => '{"factType":"unknown","factText":"x"}\n',
+        createDb: () => ({
+          // biome-ignore lint/suspicious/noExplicitAny: not reached
+          db: {} as any,
+          close: async () => undefined,
+        }),
+      }),
+    ).rejects.toThrow(/Invalid factType/);
   });
 });

--- a/packages/cli/src/commands/recover.ts
+++ b/packages/cli/src/commands/recover.ts
@@ -1,5 +1,16 @@
+import { readFile } from 'node:fs/promises';
 import { Octokit } from '@octokit/rest';
 import type { PRRef, ReviewState, VCS } from '@review-agent/core';
+import {
+  createDbClient,
+  type DbClient,
+  type RecoverEvalEventsResult,
+  type RecoverFeedbackHistoryCandidate,
+  type RecoverFeedbackHistoryResult,
+  recoverFeedbackHistory,
+  recoverReviewEvalEvents,
+  withTenant,
+} from '@review-agent/db';
 import { createGithubVCS } from '@review-agent/platform-github';
 import type { ProgramIo } from '../io.js';
 
@@ -133,4 +144,152 @@ function requireUpsertCallback(io: ProgramIo): NonNullable<RecoverSyncStateOpts[
     io.stderr('`recover sync-state` requires an upsertState callback to persist results.\n');
     throw new Error('upsertState callback not provided');
   };
+}
+
+// ---------------------------------------------------------------------------
+// v1.2 #105 — `recover review-eval-events` / `recover feedback-history`.
+//
+// Both subcommands run under a single tenant (`--installation-id` +
+// `--repo`) and are idempotent: re-running with the same args inserts
+// nothing on the second pass.
+// ---------------------------------------------------------------------------
+
+export type RecoverReviewEvalEventsOpts = {
+  readonly repo: string;
+  readonly installationId: bigint;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform?: RecoverPlatform;
+  readonly since?: string;
+  readonly dryRun?: boolean;
+  /** Test seam — provides a DbClient + close pair. */
+  readonly createDb?: (url: string) => { db: DbClient; close: () => Promise<void> };
+};
+
+export async function recoverReviewEvalEventsCommand(
+  io: ProgramIo,
+  opts: RecoverReviewEvalEventsOpts,
+): Promise<RecoverEvalEventsResult> {
+  if ((opts.platform ?? 'github') === 'codecommit') {
+    io.stderr(
+      'recover review-eval-events: --platform codecommit is supported (cost_ledger source is provider-agnostic); pass --platform github for the same effect or omit.\n',
+    );
+  }
+  const dbUrl = opts.env.DATABASE_URL ?? '';
+  if (!dbUrl) {
+    io.stderr('DATABASE_URL is required for `recover review-eval-events`.\n');
+    return { status: 'ok', candidates: 0, recovered: 0, skippedExisting: 0 };
+  }
+  const makeDb = opts.createDb ?? ((u: string) => createDbClient({ url: u }));
+  const { db, close } = makeDb(dbUrl);
+  try {
+    const since = opts.since ? new Date(opts.since) : undefined;
+    const result = await withTenant(db, opts.installationId, () =>
+      recoverReviewEvalEvents(db, {
+        installationId: opts.installationId,
+        repo: opts.repo,
+        ...(since ? { since } : {}),
+        ...(opts.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
+      }),
+    );
+    io.stdout(
+      `review-eval-events recovery for installation=${opts.installationId} repo=${opts.repo}: ` +
+        `candidates=${result.candidates} recovered=${result.recovered} skippedExisting=${result.skippedExisting}` +
+        (opts.dryRun ? ' (dry-run; no inserts)' : '') +
+        '\n',
+    );
+    return result;
+  } finally {
+    await close();
+  }
+}
+
+export type RecoverFeedbackHistoryOpts = {
+  readonly repo: string;
+  readonly installationId: bigint;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: RecoverPlatform;
+  readonly candidatesFile: string;
+  readonly dryRun?: boolean;
+  readonly createDb?: (url: string) => { db: DbClient; close: () => Promise<void> };
+  /** Test seam: read the candidates file from disk. */
+  readonly readFile?: (path: string) => Promise<string>;
+};
+
+export async function recoverFeedbackHistoryCommand(
+  io: ProgramIo,
+  opts: RecoverFeedbackHistoryOpts,
+): Promise<RecoverFeedbackHistoryResult> {
+  // Locked Q2: GitHub-only in v1.2. CodeCommit `/feedback` re-scrape
+  // is tracked separately as #110.
+  if (opts.platform === 'codecommit') {
+    io.stderr(
+      'recover feedback-history: --platform codecommit is not yet supported. ' +
+        'CodeCommit /feedback re-scrape is tracked as #110.\n',
+    );
+    return { status: 'ok', candidates: 0, recovered: 0, skippedExisting: 0 };
+  }
+  const dbUrl = opts.env.DATABASE_URL ?? '';
+  if (!dbUrl) {
+    io.stderr('DATABASE_URL is required for `recover feedback-history`.\n');
+    return { status: 'ok', candidates: 0, recovered: 0, skippedExisting: 0 };
+  }
+  const reader = opts.readFile ?? ((p: string) => readFile(p, 'utf8'));
+  const raw = await reader(opts.candidatesFile);
+  const candidates = parseCandidatesFile(raw);
+  const makeDb = opts.createDb ?? ((u: string) => createDbClient({ url: u }));
+  const { db, close } = makeDb(dbUrl);
+  try {
+    const result = await withTenant(db, opts.installationId, () =>
+      recoverFeedbackHistory(db, {
+        installationId: opts.installationId,
+        repo: opts.repo,
+        candidates,
+        ...(opts.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
+      }),
+    );
+    io.stdout(
+      `feedback-history recovery for installation=${opts.installationId} repo=${opts.repo}: ` +
+        `candidates=${result.candidates} recovered=${result.recovered} skippedExisting=${result.skippedExisting}` +
+        (opts.dryRun ? ' (dry-run; no inserts)' : '') +
+        '\n',
+    );
+    return result;
+  } finally {
+    await close();
+  }
+}
+
+/**
+ * Parses a JSONL candidates file produced by the operator from an
+ * out-of-band source (logs, prior `feedback backfill --dry-run`
+ * export, manual SQL extract). One JSON object per line:
+ *
+ *   { "factType": "rejected_finding", "factText": "[fp:abcdef0123456789] ..." }
+ *
+ * Blank lines and `//`-prefixed comments are ignored so operators can
+ * annotate.
+ */
+function parseCandidatesFile(raw: string): RecoverFeedbackHistoryCandidate[] {
+  const lines = raw.split('\n');
+  const out: RecoverFeedbackHistoryCandidate[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('//')) continue;
+    const parsed = JSON.parse(trimmed) as {
+      factType?: string;
+      factText?: string;
+    };
+    if (
+      parsed.factType !== 'accepted_pattern' &&
+      parsed.factType !== 'rejected_finding' &&
+      parsed.factType !== 'arch_decision'
+    ) {
+      throw new Error(`Invalid factType in candidates file: ${String(parsed.factType)}`);
+    }
+    if (typeof parsed.factText !== 'string' || parsed.factText === '') {
+      throw new Error('Invalid factText in candidates file (must be a non-empty string).');
+    }
+    out.push({ factType: parsed.factType, factText: parsed.factText });
+  }
+  return out;
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,7 +3,11 @@ import { auditExportCommand } from './commands/audit-export.js';
 import { auditPruneCommand } from './commands/audit-prune.js';
 import { runEvalCommand } from './commands/eval.js';
 import { feedbackBackfillCommand } from './commands/feedback-backfill.js';
-import { recoverSyncStateCommand } from './commands/recover.js';
+import {
+  recoverFeedbackHistoryCommand,
+  recoverReviewEvalEventsCommand,
+  recoverSyncStateCommand,
+} from './commands/recover.js';
 import { runReviewCommand } from './commands/review.js';
 import { printSchemaCommand } from './commands/schema.js';
 import { setupWorkspaceCommand } from './commands/setup-workspace.js';
@@ -219,9 +223,73 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
       io.exit(result.status === 'auth_failed' ? 1 : 0);
     });
 
+  recover
+    .command('review-eval-events')
+    .description(
+      'Recover review_eval_event rows from cost_ledger aggregation (v1.2 #105). Idempotent: re-running with the same args inserts nothing on the second pass.',
+    )
+    .requiredOption('--repo <owner/repo>', 'repository in `owner/name` format')
+    .requiredOption('--installation-id <id>', 'installation ID', (v) => BigInt(v))
+    .option('--since <YYYY-MM-DD>', 'only consider cost_ledger rows newer than this date')
+    .option('--dry-run', 'count candidates but do not insert', false)
+    .action(async (opts: RecoverEvalEventsCliOpts) => {
+      await recoverReviewEvalEventsCommand(io, {
+        repo: opts.repo,
+        installationId: opts.installationId,
+        env,
+        ...(opts.since ? { since: opts.since } : {}),
+        dryRun: opts.dryRun ?? false,
+      });
+      io.exit(0);
+    });
+
+  recover
+    .command('feedback-history')
+    .description(
+      'Recover review_history rows from an operator-supplied candidates JSONL file (v1.2 #105). GitHub-only; CodeCommit is tracked as #110. Idempotent against existing fact_text values.',
+    )
+    .requiredOption('--repo <owner/repo>', 'repository in `owner/name` format')
+    .requiredOption('--installation-id <id>', 'installation ID', (v) => BigInt(v))
+    .addOption(
+      new Option('--platform <platform>', 'VCS platform (default: github)')
+        .choices([...PLATFORMS])
+        .default('github'),
+    )
+    .requiredOption(
+      '--candidates-file <path>',
+      'JSONL file of {factType, factText} candidates; one row per line',
+    )
+    .option('--dry-run', 'count candidates vs existing rows but do not insert', false)
+    .action(async (opts: RecoverFeedbackHistoryCliOpts) => {
+      await recoverFeedbackHistoryCommand(io, {
+        repo: opts.repo,
+        installationId: opts.installationId,
+        platform: opts.platform,
+        env,
+        candidatesFile: opts.candidatesFile,
+        dryRun: opts.dryRun ?? false,
+      });
+      io.exit(0);
+    });
+
   program.exitOverride();
   return program;
 }
+
+type RecoverEvalEventsCliOpts = {
+  repo: string;
+  installationId: bigint;
+  since?: string;
+  dryRun?: boolean;
+};
+
+type RecoverFeedbackHistoryCliOpts = {
+  repo: string;
+  installationId: bigint;
+  platform: (typeof PLATFORMS)[number];
+  candidatesFile: string;
+  dryRun?: boolean;
+};
 
 type ReviewCliOpts = {
   repo: string;

--- a/packages/core/src/comment-fingerprint.test.ts
+++ b/packages/core/src/comment-fingerprint.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { appendFingerprintMarker, extractFingerprintFromComment } from './comment-fingerprint.js';
+
+describe('appendFingerprintMarker', () => {
+  it('appends the marker on its own paragraph by default', () => {
+    expect(appendFingerprintMarker('finding text', 'abcdef0123456789')).toBe(
+      'finding text\n\n<!-- fingerprint:abcdef0123456789 -->',
+    );
+  });
+
+  it('preserves a single trailing newline (no double-blank)', () => {
+    expect(appendFingerprintMarker('finding text\n', 'abcdef0123456789')).toBe(
+      'finding text\n<!-- fingerprint:abcdef0123456789 -->',
+    );
+  });
+
+  it('is idempotent when the same marker already trails the body', () => {
+    const once = appendFingerprintMarker('finding', 'abcdef0123456789');
+    expect(appendFingerprintMarker(once, 'abcdef0123456789')).toBe(once);
+  });
+
+  it('appends a fresh marker when a different fingerprint already trails', () => {
+    const stale = appendFingerprintMarker('finding', 'aaaaaaaa11111111');
+    const refreshed = appendFingerprintMarker(stale, 'bbbbbbbb22222222');
+    // The reader returns the FIRST match, so a stale leading marker
+    // would win — we therefore expect the new marker to follow.
+    expect(refreshed).toContain('<!-- fingerprint:aaaaaaaa11111111 -->');
+    expect(refreshed).toContain('<!-- fingerprint:bbbbbbbb22222222 -->');
+  });
+
+  it('handles multi-line bodies', () => {
+    const body = 'line one\nline two\n```ts\ncode\n```';
+    const out = appendFingerprintMarker(body, 'feedbeef12345678');
+    expect(out).toBe(`${body}\n\n<!-- fingerprint:feedbeef12345678 -->`);
+  });
+});
+
+describe('extractFingerprintFromComment', () => {
+  it('returns null when no marker is present', () => {
+    expect(extractFingerprintFromComment('plain body, no marker')).toBeNull();
+  });
+
+  it('returns null when the fingerprint is shorter than 8 hex chars', () => {
+    expect(extractFingerprintFromComment('<!-- fingerprint:abc1 -->')).toBeNull();
+  });
+
+  it('extracts a 16-hex fingerprint', () => {
+    expect(
+      extractFingerprintFromComment('finding text\n\n<!-- fingerprint:abcdef0123456789 -->'),
+    ).toBe('abcdef0123456789');
+  });
+
+  it('extracts an 8-hex prefix (matches /feedback fp_prefix argument)', () => {
+    expect(extractFingerprintFromComment('foo <!-- fingerprint:deadbeef --> bar')).toBe('deadbeef');
+  });
+
+  it('is case-insensitive and lowercases the captured fingerprint', () => {
+    expect(extractFingerprintFromComment('<!-- FINGERPRINT:ABCD1234 -->')).toBe('abcd1234');
+  });
+
+  it('tolerates extra whitespace inside the marker', () => {
+    expect(extractFingerprintFromComment('<!--   fingerprint:deadbeef01  -->')).toBe('deadbeef01');
+  });
+
+  it('does not collide with the v0.1 state comment marker', () => {
+    // Existing state-comment marker shape — must not be misread as a
+    // fingerprint marker even though both are HTML comments.
+    expect(
+      extractFingerprintFromComment('<!-- review-agent-state:v1 lastReviewedSha=abcdef -->'),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/comment-fingerprint.ts
+++ b/packages/core/src/comment-fingerprint.ts
@@ -1,0 +1,57 @@
+/**
+ * Embedding format for the inline-comment fingerprint that travels
+ * with each Bot-posted PR / MR comment so command-based feedback
+ * (`/feedback accept`, `/feedback reject` — #95) can resolve which
+ * finding the operator is reacting to without DB lookups.
+ *
+ * Format: `<!-- fingerprint:<16-hex> -->`
+ *
+ * - `<16-hex>` is the full 16-char `fingerprint()` output from
+ *   `./fingerprint.ts` (the same value stored in
+ *   `ReviewState.commentFingerprints`).
+ * - GitHub and CodeCommit both render this as a hidden HTML comment,
+ *   so end-user UX is unaffected. The marker is stripped by readers
+ *   that need plain text.
+ * - The regex tolerates extra whitespace inside the marker so casual
+ *   manual edits do not break resolution, and accepts prefixes ≥ 8
+ *   chars so #95's `/feedback <fp_prefix>` argument path can share
+ *   the same constant.
+ *
+ * spec §7.6.1 (review_history reader / writer) + #96.
+ */
+
+const FINGERPRINT_MARKER_REGEX = /<!--\s*fingerprint:([0-9a-f]{8,16})\s*-->/i;
+
+/**
+ * Append the hidden `<!-- fingerprint:<fp> -->` marker to a comment
+ * body so a downstream reader can recover the fingerprint via
+ * `extractFingerprintFromComment`. Adapters (`@review-agent/platform-*`)
+ * call this once per inline comment in their `postReview` path.
+ *
+ * Idempotent: if the body already ends with the same marker the
+ * original body is returned unchanged. This keeps re-posts from
+ * accumulating duplicate markers if a caller forgets to strip first.
+ */
+export function appendFingerprintMarker(body: string, fingerprint: string): string {
+  const expected = `<!-- fingerprint:${fingerprint} -->`;
+  if (body.trimEnd().endsWith(expected)) return body;
+  const sep = body.endsWith('\n') ? '' : '\n\n';
+  return `${body}${sep}${expected}`;
+}
+
+/**
+ * Reader-side helper. Returns the first fingerprint embedded in the
+ * comment body (lowercased), or `null` when no marker is present.
+ *
+ * Reader is intentionally tolerant:
+ * - Case-insensitive (`Fingerprint:` and `FINGERPRINT:` accepted).
+ * - Extra whitespace inside the marker permitted.
+ * - 8–16 hex chars accepted so #95's `/feedback <fp_prefix>` can
+ *   funnel through the same regex even with partial fingerprints
+ *   pasted by the operator.
+ */
+export function extractFingerprintFromComment(body: string): string | null {
+  const m = body.match(FINGERPRINT_MARKER_REGEX);
+  if (!m || !m[1]) return null;
+  return m[1].toLowerCase();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,10 @@ export {
   verifyAuditChainSegment,
 } from './audit.js';
 export {
+  appendFingerprintMarker,
+  extractFingerprintFromComment,
+} from './comment-fingerprint.js';
+export {
   COST_THRESHOLDS,
   type CostGuardDecision,
   type CostLedgerRecorder,

--- a/packages/db/src/__tests__/migration-compat.integration.test.ts
+++ b/packages/db/src/__tests__/migration-compat.integration.test.ts
@@ -1,0 +1,202 @@
+import { costLedger, reviewEvalEvent } from '@review-agent/core/db';
+import { sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { createDbClient } from '../connection.js';
+import { createReviewEvalEventRecorder } from '../review-eval-event.js';
+import { createReviewHistoryWriter, loadRecentReviewHistory } from '../review-history.js';
+import { withTenant } from '../tenancy.js';
+
+// v1.2 #107. The migration is forward-compatible: v1.1 code keeps
+// working against the v1.2-migrated schema. These tests run against
+// a real Postgres so the default expressions (`expires_at DEFAULT
+// now() + interval '180 days'`) and column-add idempotency are
+// observed by an actual planner, not just the Drizzle types.
+//
+// Gated on `TEST_DATABASE_APP_URL` (the appRole connection used by
+// every RLS-aware integration test in this package). Without it the
+// `describe` block is skipped and the file passes — the same shape as
+// `audit-retention.integration.test.ts` and `integration.test.ts`.
+
+const url = process.env.TEST_DATABASE_URL ?? '';
+const appUrl = process.env.TEST_DATABASE_APP_URL ?? '';
+
+describe.skipIf(!url || !appUrl)('migration 0003 forward-compat (#107)', () => {
+  it('cost_ledger inserts that omit latency_ms still succeed; column defaults to 0 (v1.1 → v1.2 forward-compat)', async () => {
+    // v1.1 callers do not know the column exists. The migration adds
+    // it with `DEFAULT 0`, so v1.1 inserts must continue to work
+    // unchanged. We assert both directions: insert succeeds AND the
+    // column reads back as 0 (NOT NULL). A future migration that
+    // drops the default would break this test.
+    const { db, close } = createDbClient({ url: appUrl });
+    try {
+      const tenant = 4242n;
+      const jobId = `v107-cost-${Date.now()}`;
+      await withTenant(db, tenant, async () => {
+        await db.insert(costLedger).values({
+          installationId: tenant,
+          jobId,
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          callPhase: 'review_main',
+          inputTokens: 100,
+          outputTokens: 50,
+          costUsd: 0.001,
+        });
+      });
+      const rows = (await db.execute(
+        sql`SELECT latency_ms FROM cost_ledger WHERE job_id = ${jobId}`,
+      )) as ReadonlyArray<{ latency_ms: number | null }>;
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.latency_ms ?? null).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it('review_eval_event recorder uses the documented input shape and round-trips latency_ms (Phase 2 contract)', async () => {
+    // Narrow promise: a missing `review_eval_event` table (the only
+    // "migration not applied" state we can simulate cleanly) would
+    // surface as a recorder throw. The runner catches that via
+    // `onEvalRecordError` (verified separately in agent.test.ts) and
+    // the review still posts. We pin the column shape here so a
+    // future schema change to the recorder requires updating both
+    // tests in lockstep.
+    const { db, close } = createDbClient({ url: appUrl });
+    try {
+      const tenant = 4243n;
+      const recorder = createReviewEvalEventRecorder(db);
+      await withTenant(db, tenant, async () => {
+        await recorder({
+          installationId: tenant,
+          jobId: `v107-eval-${Date.now()}`,
+          repo: 'almondoo/review-agent',
+          prNumber: 1,
+          headSha: 'h',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          commentCount: 1,
+          severityDist: { critical: 0, major: 0, minor: 1, info: 0 },
+          confidenceDist: { high: 1, medium: 0, low: 0 },
+          droppedDuplicates: 0,
+          droppedByFeedback: 0,
+          toolCalls: 0,
+          latencyMs: 1234,
+          costUsd: 0.002,
+          tokensInput: 200,
+          tokensOutput: 50,
+          abortReason: null,
+        });
+      });
+      const rows = await withTenant(db, tenant, () =>
+        db
+          .select({
+            latencyMs: reviewEvalEvent.latencyMs,
+          })
+          .from(reviewEvalEvent)
+          .where(sql`${reviewEvalEvent.installationId} = ${tenant}`),
+      );
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[0]?.latencyMs).toBe(1234);
+    } finally {
+      await close();
+    }
+  });
+
+  it('review_history.expires_at defaults to ~now + 180 days (boundary 179.95 < delta < 180.05)', async () => {
+    // Pin the default expression so a future migration that drops
+    // the `DEFAULT now() + interval '180 days'` (or bumps it to 365)
+    // is caught immediately. The migration target is to keep this
+    // window stable; spec §7.6 sets the TTL.
+    const { db, close } = createDbClient({ url: appUrl });
+    try {
+      const tenant = 4244n;
+      const writer = createReviewHistoryWriter(db);
+      await withTenant(db, tenant, async () => {
+        await writer({
+          installationId: tenant,
+          repo: 'almondoo/review-agent',
+          factType: 'rejected_finding',
+          factText: '[fp:0000000000000001] expiry boundary test',
+        });
+      });
+      const rows = (await db.execute(
+        sql`SELECT EXTRACT(EPOCH FROM (expires_at - now()))::float / 86400.0 AS delta_days
+            FROM review_history
+            WHERE installation_id = ${Number(tenant)}
+            ORDER BY id DESC
+            LIMIT 1`,
+      )) as ReadonlyArray<{ delta_days: number | string }>;
+      const deltaDays = Number(rows[0]?.delta_days ?? 0);
+      // Tight band around 180 days so accidental migration changes
+      // (now+0d, now+365d) fail immediately.
+      expect(deltaDays).toBeGreaterThan(179.95);
+      expect(deltaDays).toBeLessThan(180.05);
+    } finally {
+      await close();
+    }
+  });
+
+  it('writing review_eval_event rows does NOT side-effect review_history reads (table isolation regression guard)', async () => {
+    // Cheap guard against an accidental view / trigger / shared
+    // sequence introduced in a future migration. We snapshot
+    // review_history before + after a recorder write and assert the
+    // reader returns the same rows.
+    const { db, close } = createDbClient({ url: appUrl });
+    try {
+      const tenant = 4245n;
+      const writer = createReviewHistoryWriter(db);
+      const recorder = createReviewEvalEventRecorder(db);
+
+      await withTenant(db, tenant, async () => {
+        await writer({
+          installationId: tenant,
+          repo: 'almondoo/review-agent',
+          factType: 'accepted_pattern',
+          factText: '[fp:0000000000000002] before eval traffic',
+        });
+      });
+      const before = await withTenant(db, tenant, () =>
+        loadRecentReviewHistory(db, {
+          installationId: tenant,
+          repo: 'almondoo/review-agent',
+          limit: 50,
+        }),
+      );
+
+      await withTenant(db, tenant, async () => {
+        await recorder({
+          installationId: tenant,
+          jobId: `v107-iso-${Date.now()}`,
+          repo: 'almondoo/review-agent',
+          prNumber: 9,
+          headSha: 'h',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          commentCount: 0,
+          severityDist: { critical: 0, major: 0, minor: 0, info: 0 },
+          confidenceDist: { high: 0, medium: 0, low: 0 },
+          droppedDuplicates: 0,
+          droppedByFeedback: 0,
+          toolCalls: 0,
+          latencyMs: 0,
+          costUsd: 0,
+          tokensInput: 0,
+          tokensOutput: 0,
+          abortReason: null,
+        });
+      });
+
+      const after = await withTenant(db, tenant, () =>
+        loadRecentReviewHistory(db, {
+          installationId: tenant,
+          repo: 'almondoo/review-agent',
+          limit: 50,
+        }),
+      );
+      expect(after.length).toBe(before.length);
+      expect(after.map((r) => r.factText)).toEqual(before.map((r) => r.factText));
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29,6 +29,17 @@ export {
   verifyAuditChainSegmentFromDb,
 } from './hmac-chain.js';
 export { type MigrateOpts, runMigrations } from './migrate.js';
+export {
+  type RecoverEvalEventsOpts,
+  type RecoverEvalEventsResult,
+  recoverReviewEvalEvents,
+} from './recover-eval-events.js';
+export {
+  type RecoverFeedbackHistoryCandidate,
+  type RecoverFeedbackHistoryOpts,
+  type RecoverFeedbackHistoryResult,
+  recoverFeedbackHistory,
+} from './recover-feedback-history.js';
 export { createReviewEvalEventRecorder } from './review-eval-event.js';
 export {
   createReviewHistoryWriter,

--- a/packages/db/src/recover-eval-events.ts
+++ b/packages/db/src/recover-eval-events.ts
@@ -1,0 +1,134 @@
+import { costLedger, reviewEvalEvent } from '@review-agent/core/db';
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
+import type { DbClient } from './connection.js';
+
+/**
+ * v1.2 #105 — `recover review-eval-events` source-of-truth: aggregate
+ * `cost_ledger` per `(installation_id, job_id)` and back-fill any
+ * matching `review_eval_event` row that is missing.
+ *
+ * Locked Q1 (issue body): the financial fields (`token_input` /
+ * `token_output` / `cost_usd` / `latency_ms`) are reconstructible
+ * via SUM. The LLM-output-dependent fields (`comment_count`,
+ * `severity_dist`, `confidence_dist`, `dropped_*`, `tool_calls`,
+ * `abort_reason`) are NOT recoverable from `cost_ledger` and are
+ * filled with empty / zero defaults — the row exists for continuity
+ * but per-review analytics on those columns must treat recovered
+ * rows specially.
+ *
+ * cost_ledger does not carry `repo`, `pr_number`, or `head_sha`, so
+ * the recovery scopes by `(installation_id, --repo)` from the CLI
+ * args. The recovered row's `repo` reflects the CLI input; the
+ * per-PR fields are set to empty markers (`pr_number = 0`,
+ * `head_sha = ''`) so a downstream consumer can detect them.
+ *
+ * Idempotent: rows where `(installation_id, job_id)` already exists
+ * in `review_eval_event` are left untouched and counted as
+ * `skippedExisting`. Safe to re-run.
+ */
+export type RecoverEvalEventsOpts = {
+  readonly installationId: bigint;
+  readonly repo: string;
+  readonly since?: Date;
+  readonly dryRun?: boolean;
+};
+
+export type RecoverEvalEventsResult = {
+  readonly status: 'ok';
+  readonly candidates: number;
+  readonly recovered: number;
+  readonly skippedExisting: number;
+};
+
+export async function recoverReviewEvalEvents(
+  db: DbClient,
+  opts: RecoverEvalEventsOpts,
+): Promise<RecoverEvalEventsResult> {
+  // 1. Aggregate cost_ledger per (installation_id, job_id) for this
+  //    installation. The `provider` / `model` columns are picked via
+  //    MAX so a job with retry rows under the same model still
+  //    surfaces a stable label.
+  const candidateRows = await db
+    .select({
+      jobId: costLedger.jobId,
+      provider: sql<string>`MAX(${costLedger.provider})`,
+      model: sql<string>`MAX(${costLedger.model})`,
+      latencyMs: sql<number>`COALESCE(SUM(${costLedger.latencyMs}), 0)::int`,
+      costUsd: sql<number>`COALESCE(SUM(${costLedger.costUsd}), 0)::double precision`,
+      inputTokens: sql<number>`COALESCE(SUM(${costLedger.inputTokens}), 0)::int`,
+      outputTokens: sql<number>`COALESCE(SUM(${costLedger.outputTokens}), 0)::int`,
+    })
+    .from(costLedger)
+    .where(
+      and(
+        eq(costLedger.installationId, opts.installationId),
+        opts.since ? gte(costLedger.createdAt, opts.since) : undefined,
+      ),
+    )
+    .groupBy(costLedger.jobId);
+
+  if (candidateRows.length === 0) {
+    return { status: 'ok', candidates: 0, recovered: 0, skippedExisting: 0 };
+  }
+
+  // 2. Find which `job_id`s already exist in review_eval_event so we
+  //    skip them on insert (idempotency contract).
+  const candidateJobIds = candidateRows.map((r) => r.jobId);
+  const existingRows = await db
+    .select({ jobId: reviewEvalEvent.jobId })
+    .from(reviewEvalEvent)
+    .where(
+      and(
+        eq(reviewEvalEvent.installationId, opts.installationId),
+        inArray(reviewEvalEvent.jobId, candidateJobIds),
+      ),
+    );
+  const existing = new Set(existingRows.map((r) => r.jobId));
+  const fresh = candidateRows.filter((r) => !existing.has(r.jobId));
+
+  if (opts.dryRun || fresh.length === 0) {
+    return {
+      status: 'ok',
+      candidates: candidateRows.length,
+      recovered: 0,
+      skippedExisting: existing.size,
+    };
+  }
+
+  // 3. Insert. We use a single multi-row insert keyed by job_id so a
+  //    concurrent recovery attempt has a deterministic ordering; the
+  //    idempotency check above lets a re-run with overlapping jobs
+  //    no-op cleanly.
+  await db.insert(reviewEvalEvent).values(
+    fresh.map((r) => ({
+      installationId: opts.installationId,
+      jobId: r.jobId,
+      // cost_ledger doesn't carry these; fill with the CLI's --repo
+      // arg + empty markers. Documented as best-effort recovery
+      // (#105 Q1).
+      repo: opts.repo,
+      prNumber: 0,
+      headSha: '',
+      provider: r.provider,
+      model: r.model,
+      commentCount: 0,
+      severityDist: {},
+      confidenceDist: {},
+      droppedDuplicates: 0,
+      droppedByFeedback: 0,
+      toolCalls: 0,
+      latencyMs: r.latencyMs,
+      costUsd: r.costUsd,
+      tokensInput: r.inputTokens,
+      tokensOutput: r.outputTokens,
+      abortReason: null,
+    })),
+  );
+
+  return {
+    status: 'ok',
+    candidates: candidateRows.length,
+    recovered: fresh.length,
+    skippedExisting: existing.size,
+  };
+}

--- a/packages/db/src/recover-feedback-history.ts
+++ b/packages/db/src/recover-feedback-history.ts
@@ -1,0 +1,90 @@
+import { reviewHistory } from '@review-agent/core/db';
+import { and, eq } from 'drizzle-orm';
+import type { DbClient } from './connection.js';
+
+/**
+ * v1.2 #105 — `recover feedback-history` (GitHub only) helper.
+ *
+ * Idempotency layer over the existing `createReviewHistoryWriter`.
+ * The caller (CLI `recover feedback-history --platform github`)
+ * collects candidate `(factType, factText)` events from the GitHub
+ * reactions API (same source as #99 `feedback backfill`) and passes
+ * them here. We:
+ *
+ *   1. Snapshot the existing `review_history` rows for the scoped
+ *      `(installation_id, repo)` so duplicate `fact_text` is not
+ *      re-inserted.
+ *   2. Insert only the candidates whose `fact_text` is missing from
+ *      the snapshot.
+ *
+ * The `--platform codecommit` path is reject-only in v1.2: the
+ * CodeCommit `/feedback` re-scrape is carved out as issue #110.
+ * This module never sees a CodeCommit candidate.
+ *
+ * Idempotency key: full `fact_text` equality. The Phase 3 writer
+ * encodes `[fp:<fingerprint>] <redacted text>` so the prefix alone
+ * makes two events on the same fingerprint collide reliably. A
+ * future migration could promote this to a unique index on
+ * `(installation_id, repo, fact_text)` — for now we serialise the
+ * dedup in code so existing rows are not retro-rejected.
+ */
+export type RecoverFeedbackHistoryCandidate = {
+  readonly factType: 'accepted_pattern' | 'rejected_finding' | 'arch_decision';
+  readonly factText: string;
+};
+
+export type RecoverFeedbackHistoryOpts = {
+  readonly installationId: bigint;
+  readonly repo: string;
+  readonly candidates: ReadonlyArray<RecoverFeedbackHistoryCandidate>;
+  readonly dryRun?: boolean;
+};
+
+export type RecoverFeedbackHistoryResult = {
+  readonly status: 'ok';
+  readonly candidates: number;
+  readonly recovered: number;
+  readonly skippedExisting: number;
+};
+
+export async function recoverFeedbackHistory(
+  db: DbClient,
+  opts: RecoverFeedbackHistoryOpts,
+): Promise<RecoverFeedbackHistoryResult> {
+  if (opts.candidates.length === 0) {
+    return { status: 'ok', candidates: 0, recovered: 0, skippedExisting: 0 };
+  }
+  const existing = await db
+    .select({ factText: reviewHistory.factText })
+    .from(reviewHistory)
+    .where(
+      and(eq(reviewHistory.installationId, opts.installationId), eq(reviewHistory.repo, opts.repo)),
+    );
+  const existingSet = new Set(existing.map((r) => r.factText));
+
+  const fresh = opts.candidates.filter((c) => !existingSet.has(c.factText));
+  if (opts.dryRun || fresh.length === 0) {
+    return {
+      status: 'ok',
+      candidates: opts.candidates.length,
+      recovered: 0,
+      skippedExisting: opts.candidates.length - fresh.length,
+    };
+  }
+
+  await db.insert(reviewHistory).values(
+    fresh.map((c) => ({
+      installationId: opts.installationId,
+      repo: opts.repo,
+      factType: c.factType,
+      factText: c.factText,
+    })),
+  );
+
+  return {
+    status: 'ok',
+    candidates: opts.candidates.length,
+    recovered: fresh.length,
+    skippedExisting: opts.candidates.length - fresh.length,
+  };
+}

--- a/packages/platform-codecommit/src/adapter.test.ts
+++ b/packages/platform-codecommit/src/adapter.test.ts
@@ -237,6 +237,62 @@ describe('createCodecommitVCS — postReview', () => {
     };
     expect(inlineLeft.location.relativeFileVersion).toBe('BEFORE');
   });
+
+  it('appends the hidden fingerprint marker to each inline comment body (#96)', async () => {
+    const seen: Array<{ name: string; input: unknown }> = [];
+    const client = {
+      send: vi.fn(async (cmd: { constructor: { name: string }; input: unknown }) => {
+        seen.push({ name: cmd.constructor.name, input: cmd.input });
+        if (cmd.constructor.name === 'GetPullRequestCommand') {
+          return {
+            pullRequest: {
+              pullRequestTargets: [{ sourceCommit: 'h1', destinationCommit: 'b1' }],
+            },
+          };
+        }
+        return { comment: { commentId: 'cid' } };
+      }),
+    };
+    const vcs = createCodecommitVCS({ client });
+    await vcs.postReview(REF, {
+      summary: 'two findings',
+      comments: [
+        {
+          path: 'a.ts',
+          line: 1,
+          side: 'RIGHT',
+          body: 'first finding',
+          fingerprint: 'abcdef0123456789',
+          severity: 'minor',
+        },
+        {
+          path: 'b.ts',
+          line: 5,
+          side: 'RIGHT',
+          body: 'second finding\nwith two lines',
+          fingerprint: 'fedcba9876543210',
+          severity: 'critical',
+        },
+      ],
+      state: {
+        schemaVersion: 1,
+        lastReviewedSha: 'h1',
+        baseSha: 'b1',
+        reviewedAt: '2026-04-30T00:00:00Z',
+        modelUsed: 'm',
+        totalTokens: 0,
+        totalCostUsd: 0,
+        commentFingerprints: ['abcdef0123456789', 'fedcba9876543210'],
+      },
+    });
+    const inlinePosts = seen.filter((s) => s.name === 'PostCommentForPullRequestCommand').slice(1); // first post is the summary
+    expect((inlinePosts[0]?.input as { content: string }).content).toBe(
+      'first finding\n\n<!-- fingerprint:abcdef0123456789 -->',
+    );
+    expect((inlinePosts[1]?.input as { content: string }).content).toBe(
+      'second finding\nwith two lines\n\n<!-- fingerprint:fedcba9876543210 -->',
+    );
+  });
 });
 
 describe('createCodecommitVCS — postReview approvalState mapping (#74)', () => {

--- a/packages/platform-codecommit/src/adapter.ts
+++ b/packages/platform-codecommit/src/adapter.ts
@@ -13,18 +13,19 @@ import {
   type PullRequest,
   UpdatePullRequestApprovalStateCommand,
 } from '@aws-sdk/client-codecommit';
-import type {
-  CloneOpts,
-  Diff,
-  DiffFile,
-  ExistingComment,
-  GetDiffOpts,
-  PR,
-  PRRef,
-  ReviewPayload,
-  ReviewState,
-  VCS,
-  VcsCapabilities,
+import {
+  appendFingerprintMarker,
+  type CloneOpts,
+  type Diff,
+  type DiffFile,
+  type ExistingComment,
+  type GetDiffOpts,
+  type PR,
+  type PRRef,
+  type ReviewPayload,
+  type ReviewState,
+  type VCS,
+  type VcsCapabilities,
 } from '@review-agent/core';
 
 /**
@@ -232,6 +233,9 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
       );
     }
     for (const c of review.comments) {
+      // #96: same hidden marker as the GitHub adapter so a
+      // CodeCommit `/feedback` (#95) reply can resolve the target
+      // comment via its parent body.
       await client.send(
         new PostCommentForPullRequestCommand({
           pullRequestId: toPullRequestId(ref),
@@ -243,7 +247,7 @@ export function createCodecommitVCS(opts: CodeCommitVCSOptions = {}): VCS {
             filePosition: c.line,
             relativeFileVersion: c.side === 'LEFT' ? 'BEFORE' : 'AFTER',
           },
-          content: c.body,
+          content: appendFingerprintMarker(c.body, c.fingerprint),
         }),
       );
     }

--- a/packages/platform-github/src/adapter.test.ts
+++ b/packages/platform-github/src/adapter.test.ts
@@ -469,6 +469,44 @@ describe('postReview', () => {
     const args = createReview.mock.calls[0]?.[0] as { event: string };
     expect(args.event).toBe('COMMENT');
   });
+
+  it('appends the hidden fingerprint marker to each inline comment body (#96)', async () => {
+    const createReview = vi.fn(async () => ({ data: { id: 4 } }));
+    const vcs = createGithubVCS({
+      token: 't',
+      octokit: createMockOctokit({ pulls: { createReview } }),
+    });
+    const review: ReviewPayload = {
+      summary: 'two findings',
+      comments: [
+        {
+          path: 'a.ts',
+          line: 1,
+          side: 'RIGHT',
+          body: 'first finding',
+          severity: 'minor',
+          fingerprint: 'abcdef0123456789',
+        },
+        {
+          path: 'b.ts',
+          line: 5,
+          side: 'RIGHT',
+          body: 'second finding\nwith two lines',
+          severity: 'critical',
+          fingerprint: 'fedcba9876543210',
+        },
+      ],
+      state: validState,
+    };
+    await vcs.postReview(ref, review);
+    const args = createReview.mock.calls[0]?.[0] as {
+      comments: { body: string }[];
+    };
+    expect(args.comments[0]?.body).toBe('first finding\n\n<!-- fingerprint:abcdef0123456789 -->');
+    expect(args.comments[1]?.body).toBe(
+      'second finding\nwith two lines\n\n<!-- fingerprint:fedcba9876543210 -->',
+    );
+  });
 });
 
 describe('getStateComment / upsertStateComment', () => {

--- a/packages/platform-github/src/adapter.ts
+++ b/packages/platform-github/src/adapter.ts
@@ -1,17 +1,18 @@
 import { Buffer } from 'node:buffer';
 import { Octokit } from '@octokit/rest';
-import type {
-  CloneOpts,
-  Diff,
-  DiffFile,
-  ExistingComment,
-  GetDiffOpts,
-  PR,
-  PRRef,
-  ReviewPayload,
-  ReviewState,
-  VCS,
-  VcsCapabilities,
+import {
+  appendFingerprintMarker,
+  type CloneOpts,
+  type Diff,
+  type DiffFile,
+  type ExistingComment,
+  type GetDiffOpts,
+  type PR,
+  type PRRef,
+  type ReviewPayload,
+  type ReviewState,
+  type VCS,
+  type VcsCapabilities,
 } from '@review-agent/core';
 
 /**
@@ -268,11 +269,14 @@ export function createGithubVCS(opts: GithubVCSOptions): VCS {
   const postReview = async (ref: PRRef, review: ReviewPayload): Promise<void> => {
     ensureGithub(ref);
     const summaryWithState = buildSummaryWithState(review.summary, review.state);
+    // #96: append the hidden `<!-- fingerprint:<fp> -->` marker so the
+    // `/feedback` command (#95) can resolve the target inline comment
+    // by reading its parent body, without a DB round-trip.
     const comments = review.comments.map((c) => ({
       path: c.path,
       line: c.line,
       side: c.side,
-      body: c.body,
+      body: appendFingerprintMarker(c.body, c.fingerprint),
     }));
     // `event` is optional on ReviewPayload so callers that haven't
     // been updated (or third-party adapters via the VCS interface)

--- a/packages/runner/src/__tests__/self-feedback-loop.test.ts
+++ b/packages/runner/src/__tests__/self-feedback-loop.test.ts
@@ -1,0 +1,229 @@
+import { fingerprint } from '@review-agent/core';
+import type { LlmProvider, ReviewOutput } from '@review-agent/llm';
+import { describe, expect, it, vi } from 'vitest';
+import { runReview } from '../agent.js';
+import { createFeedbackWriter, type ReviewHistoryWriter } from '../feedback-writer.js';
+import type { ReviewJob } from '../types.js';
+
+// v1.2 #108 — Phase 3 → Phase 4 self-feedback round-trip.
+//
+// **Scope note**: the issue body suggests
+// `packages/runner/src/__tests__/self-feedback-loop.integration.test.ts`
+// gated on `TEST_DATABASE_APP_URL`. The `@review-agent/runner` package
+// does NOT currently depend on `@review-agent/db` (the runner's
+// `ReviewHistoryWriter` / `historyReader` are abstract function types
+// the worker layer fulfils — adding a real Postgres workspace dep to
+// the runner would invert the direction of `db` → `runner` cleanly
+// enforced by `server`).
+//
+// The actual risk identified in the issue's Motivation section —
+// "the `[fp:<fingerprint>]` prefix is the ONLY link between Phase 3
+// writer and Phase 4 reader; a silent format mismatch makes the
+// whole loop go quiet" — is **protocol-level**, not driver-level.
+// We pin the protocol here with an in-memory store that exercises:
+//
+//   * createFeedbackWriter() encodes `[fp:<fp>] ...` correctly.
+//   * The same fingerprint that `runReview` attached on review #1
+//     is what the writer persists.
+//   * On review #2, the runner's `historyReader` returns the row
+//     and the dedup middleware drops the matching comment via
+//     `droppedByFeedback`.
+//
+// A Postgres-backed integration test that simply replays this same
+// pattern through `createReviewHistoryWriter` + `loadRecentReviewHistory`
+// from `@review-agent/db` would catch driver-layer regressions (RLS
+// GUC propagation, expires_at default expression) — covered by
+// `packages/db/src/__tests__/integration.test.ts` for the writer /
+// reader unit halves, and by `migration-compat.integration.test.ts`
+// (#107) for the schema invariants. Stitching those two halves into
+// a runner-side integration test is tracked as a follow-up if the
+// runner ever gains a `@review-agent/db` devDep.
+
+const baseJob: ReviewJob = {
+  jobId: 'job-self-feedback',
+  workspaceDir: '/tmp/job-self-feedback',
+  diffText: 'diff --git a/x b/x',
+  prMetadata: { title: 'feature', body: '', author: 'alice' },
+  previousState: null,
+  profile: 'TS-only.',
+  pathInstructions: [],
+  skills: [],
+  language: 'en-US',
+  costCapUsd: 2.0,
+  pathFilters: [],
+  maxFiles: 50,
+  maxDiffLines: 3000,
+  privacy: { allowedUrlPrefixes: [], denyPaths: [], redactPatterns: [] },
+  prRepo: { host: 'github.com', owner: 'almondoo', repo: 'review-agent' },
+};
+
+// Deterministic LLM output — one finding the model will emit on
+// every review.
+const stableComment = {
+  path: 'src/auth.ts',
+  line: 10,
+  side: 'RIGHT' as const,
+  body: 'Use parameterized query.',
+  severity: 'major' as const,
+  ruleId: 'sql-injection',
+};
+
+const validOutput: ReviewOutput = {
+  summary: 'One finding.',
+  comments: [stableComment],
+  tokensUsed: { input: 200, output: 50 },
+  costUsd: 0.001,
+};
+
+function makeProvider(): LlmProvider {
+  return {
+    name: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    classifyError: vi.fn(() => ({ kind: 'fatal' as const })),
+    pricePerMillionTokens: vi.fn(() => ({ input: 3, output: 15 })),
+    estimateCost: vi.fn(async () => ({ inputTokens: 200, estimatedUsd: 0.001 })),
+    generateReview: vi.fn(async () => validOutput),
+  };
+}
+
+// In-memory store playing the role of the `review_history` table.
+type StoredRow = {
+  readonly factType: 'accepted_pattern' | 'rejected_finding' | 'arch_decision';
+  readonly factText: string;
+};
+
+function makeStore(): {
+  readonly writer: ReviewHistoryWriter;
+  readonly rows: ReadonlyArray<StoredRow>;
+} {
+  const rows: StoredRow[] = [];
+  const writer: ReviewHistoryWriter = async (input) => {
+    rows.push({ factType: input.factType, factText: input.factText });
+  };
+  return {
+    writer,
+    get rows() {
+      return rows;
+    },
+  };
+}
+
+describe('self-feedback loop — Phase 3 writer → Phase 4 reader round-trip (#108)', () => {
+  it('the fingerprint the writer persists is recoverable by the reader, and dedup drops the matching comment on review #2', async () => {
+    const provider = makeProvider();
+    const store = makeStore();
+
+    // Review #1 — capture the fingerprint the dedup middleware
+    // attached to the stable comment.
+    const r1 = await runReview(baseJob, provider);
+    expect(r1.comments).toHaveLength(1);
+    const fp = r1.comments[0]?.fingerprint;
+    expect(fp).toBeTruthy();
+    expect(fp).toBe(
+      // Sanity-pin: the runner uses (path, line, ruleId, suggestionType)
+      // — a future change to suggestionType / ruleId fallback would
+      // break this match silently in real deployments.
+      fingerprint({
+        path: stableComment.path,
+        line: stableComment.line,
+        ruleId: stableComment.ruleId,
+        suggestionType: 'comment',
+      }),
+    );
+
+    // Phase 3 — operator reacts 👎 on the comment. The writer
+    // encodes `[fp:<fp>] ...` into factText (single source of truth
+    // shared with Phase 4 below).
+    const feedback = createFeedbackWriter({ writer: store.writer });
+    const result = await feedback.record({
+      installationId: 4242n,
+      repo: 'almondoo/review-agent',
+      kind: 'thumbs_down',
+      fingerprint: fp ?? '',
+      factText: stableComment.body,
+    });
+    expect(result.dropped).toBe(false);
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]?.factType).toBe('rejected_finding');
+    expect(store.rows[0]?.factText.startsWith(`[fp:${fp}] `)).toBe(true);
+
+    // Phase 4 — historyReader returns the persisted rows. The
+    // runner extracts the `[fp:<fp>]` prefix and feeds it into
+    // dedup as `rejectedFingerprints`.
+    const r2 = await runReview(baseJob, provider, {
+      historyReader: async () => store.rows,
+      evalContext: { installationId: 4242n, prNumber: 7, headSha: 'h' },
+    });
+    expect(r2.droppedByFeedback).toBe(1);
+    expect(r2.comments).toHaveLength(0);
+    // System prompt must include the <learned_facts> envelope so the
+    // model also sees the operator's signal in addition to the
+    // post-LLM dedup backstop.
+    const sysPrompt = (provider.generateReview as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]
+      ?.systemPrompt as string;
+    expect(sysPrompt).toContain('<learned_facts>');
+    expect(sysPrompt).toContain(stableComment.body);
+  });
+
+  it('thumbs_up (accepted_pattern) round-trips into the prompt without suppressing the comment', async () => {
+    const provider = makeProvider();
+    const store = makeStore();
+
+    const r1 = await runReview(baseJob, provider);
+    const fp = r1.comments[0]?.fingerprint ?? '';
+    expect(fp).toBeTruthy();
+
+    const feedback = createFeedbackWriter({ writer: store.writer });
+    await feedback.record({
+      installationId: 4242n,
+      repo: 'almondoo/review-agent',
+      kind: 'thumbs_up',
+      fingerprint: fp,
+      factText: stableComment.body,
+    });
+    expect(store.rows[0]?.factType).toBe('accepted_pattern');
+
+    const r2 = await runReview(baseJob, provider, {
+      historyReader: async () => store.rows,
+      evalContext: { installationId: 4242n, prNumber: 7, headSha: 'h' },
+    });
+    // accepted_pattern does NOT add the fingerprint to the rejected
+    // set — the comment is still posted on subsequent reviews. The
+    // operator's positive signal only informs the LLM's context.
+    expect(r2.droppedByFeedback).toBe(0);
+    expect(r2.comments).toHaveLength(1);
+    const sysPrompt = (provider.generateReview as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]
+      ?.systemPrompt as string;
+    expect(sysPrompt).toContain('<learned_facts>');
+  });
+
+  it('rate-limit overflow: the 11th feedback event is dropped (10/job default cap)', async () => {
+    const store = makeStore();
+    const feedback = createFeedbackWriter({ writer: store.writer });
+
+    const events: Array<{ dropped: boolean }> = [];
+    for (let i = 0; i < 12; i += 1) {
+      // Distinct fingerprints so the writer doesn't dedup at insert.
+      events.push(
+        await feedback.record({
+          installationId: 4242n,
+          repo: 'almondoo/review-agent',
+          kind: 'thumbs_down',
+          fingerprint: fingerprint({
+            path: 'src/x.ts',
+            line: i + 1,
+            ruleId: 'minor',
+            suggestionType: 'comment',
+          }),
+          factText: `event ${i}`,
+        }),
+      );
+    }
+
+    // First 10 land; events 11 and 12 are dropped.
+    expect(events.slice(0, 10).every((e) => !e.dropped)).toBe(true);
+    expect(events[10]?.dropped).toBe(true);
+    expect(events[11]?.dropped).toBe(true);
+    expect(store.rows).toHaveLength(10);
+  });
+});

--- a/packages/runner/src/agent.test.ts
+++ b/packages/runner/src/agent.test.ts
@@ -1379,4 +1379,26 @@ describe('runReview — learned_facts injection + feedback-aware dedup (#93 / sp
     await runReview(baseJob, provider, { historyReader });
     expect(historyReader).not.toHaveBeenCalled();
   });
+
+  it('routes historyReader throws through onHistoryReaderError and still re-raises (#106)', async () => {
+    const provider = makeProvider();
+    const boom = new Error('reader exploded');
+    const historyReader = vi.fn(async () => {
+      throw boom;
+    });
+    const onHistoryReaderError = vi.fn();
+    await expect(
+      runReview(baseJob, provider, {
+        historyReader,
+        onHistoryReaderError,
+        evalContext: {
+          installationId: 1n,
+          prNumber: 7,
+          headSha: 'h',
+        },
+      }),
+    ).rejects.toBe(boom);
+    expect(onHistoryReaderError).toHaveBeenCalledTimes(1);
+    expect(onHistoryReaderError).toHaveBeenCalledWith(boom);
+  });
 });

--- a/packages/runner/src/agent.ts
+++ b/packages/runner/src/agent.ts
@@ -177,11 +177,20 @@ async function runReviewInner(
   }> = [];
   let rejectedFingerprints: ReadonlyArray<string> = [];
   if (deps.historyReader && deps.evalContext) {
-    const rows = await deps.historyReader({
-      installationId: deps.evalContext.installationId,
-      repo: `${job.prRepo.owner}/${job.prRepo.repo}`,
-      limit: MAX_LEARNED_FACTS,
-    });
+    let rows: Awaited<ReturnType<NonNullable<typeof deps.historyReader>>>;
+    try {
+      rows = await deps.historyReader({
+        installationId: deps.evalContext.installationId,
+        repo: `${job.prRepo.owner}/${job.prRepo.repo}`,
+        limit: MAX_LEARNED_FACTS,
+      });
+    } catch (err) {
+      // v1.2 #106: fire the observability hook before re-raising so the
+      // counter sees the error even though the existing behavior of
+      // bubbling the failure to the queue is preserved.
+      deps.onHistoryReaderError?.(err);
+      throw err;
+    }
     learnedFacts = rows;
     rejectedFingerprints = rows
       .filter((r) => r.factType === 'rejected_finding')

--- a/packages/runner/src/feedback-fingerprint-resolver.ts
+++ b/packages/runner/src/feedback-fingerprint-resolver.ts
@@ -1,33 +1,30 @@
+import { extractFingerprintFromComment } from '@review-agent/core';
+
 /**
- * `/feedback` fingerprint resolver — v1.2 #95.
+ * `/feedback` fingerprint resolver — v1.2 #95 + #96.
  *
  * Translates a `/feedback ...` comment plus the parent (bot) comment's
  * body plus the known set of `review_state.commentFingerprints` into a
  * concrete fingerprint that points at one of the bot's inline comments.
  *
- * Two resolution paths exist (spec §7.6 follow-on / #95 AC):
+ * Two resolution paths exist (spec §7.6 follow-on):
  *
- *   (a) **Marker extraction.** When the parent comment carries a
- *       `<!-- fingerprint:<fp> -->` HTML marker (depends on #96), the
- *       resolver pulls the fingerprint straight out of the body. This
- *       is the recommended path because it requires zero user input.
+ *   (a) **Marker extraction.** The bot embeds `<!-- fingerprint:<fp> -->`
+ *       in every inline comment (writer side: #96, via
+ *       `appendFingerprintMarker` from `@review-agent/core`). The
+ *       resolver pulls the fingerprint straight out of the parent
+ *       body. This is the recommended path because it requires zero
+ *       user input.
  *
- *   (b) **`<fp_prefix>` argument.** When the marker is absent (or
- *       #96's embedding is still pending), the user disambiguates by
- *       typing `/feedback reject <fp_prefix>` with at least 8 hex
+ *   (b) **`<fp_prefix>` argument.** When the marker is absent (e.g.
+ *       comments posted before #96 shipped), the user disambiguates
+ *       by typing `/feedback reject <fp_prefix>` with at least 8 hex
  *       chars. The resolver prefix-matches against
  *       `commentFingerprints`. Exactly one match → success. Zero
  *       matches → `no_match`. Two-or-more matches → `ambiguous_prefix`
  *       (handled by the receiver as `unresolved` for metrics).
  *
  *   (c) Neither marker nor prefix given → `no_marker_and_no_prefix`.
- *
- * NOTE: until #96 (fingerprint marker embedding in posted PR comments)
- * ships, the marker extractor is wired but always returns `null` from
- * the actual receiver path because the bot never writes the marker.
- * The regex extraction function is implemented and tested so the day
- * #96 lands the resolver picks up the (a) path with zero changes
- * here.
  */
 
 export type FingerprintResolutionInput = {
@@ -51,32 +48,13 @@ export type FingerprintResolution =
     };
 
 /**
- * Regex for the HTML-comment marker `#96` will start writing into bot
- * comments. Lowercase hex, 8+ chars, surrounded by `<!-- fingerprint:`
- * / `-->`. Matches inside a body even with surrounding text so the
- * marker can travel alongside the rendered comment.
- *
- * The marker is the **link** between a reaction-equivalent reply (CodeCommit
- * `/feedback`) and the fingerprint stored in `review_state.commentFingerprints`.
- */
-const FINGERPRINT_MARKER_REGEX = /<!--\s*fingerprint:([0-9a-f]{8,})\s*-->/i;
-
-/**
- * Pure helper: extract the marker fingerprint from a body string.
- * Returns `null` when no marker is present. Exposed for unit tests
- * so the day #96 lands its `composeStateComment` change we can flip
- * a single fixture and watch resolution succeed.
- *
- * TODO: #96 (fingerprint embedding) landed 後にここで marker 抽出を実装
- * — currently the receiver flow does not depend on the result of
- * this function because no bot comment yet carries the marker. The
- * tests pin the contract so the wiring is forward-compatible.
+ * Pure helper: extract the marker fingerprint from a body string. Thin
+ * alias for `@review-agent/core`'s `extractFingerprintFromComment` so
+ * existing callers of this resolver module keep working without
+ * importing core directly.
  */
 export function extractFingerprintMarker(body: string): string | null {
-  const m = body.match(FINGERPRINT_MARKER_REGEX);
-  if (!m) return null;
-  const fp = m[1];
-  return fp ? fp.toLowerCase() : null;
+  return extractFingerprintFromComment(body);
 }
 
 /**

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -335,6 +335,15 @@ export type RunReviewDeps = {
    */
   readonly onEvalRecordError?: (err: unknown) => void;
   /**
+   * v1.2 #106. Fired when `historyReader` (Phase 4 / #93) throws.
+   * The runner **does** re-throw — the historyReader failure is
+   * operator-visible per the v1.2 design (see `agent.ts`). The hook
+   * exists so operators can route the error to a counter
+   * (`review_agent_history_reader_errors_total`) before the cascading
+   * review failure surfaces to the queue.
+   */
+  readonly onHistoryReaderError?: (err: unknown) => void;
+  /**
    * Optional reader that loads `review_history` rows for this PR's
    * repo (v1.2 epic #83 Phase 4 / #93). When present the runner
    * splits the rows into:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,7 +12,15 @@ export {
   type WebhookResult,
 } from './handlers/webhook.js';
 export { createSqsLambdaHandler, type LambdaWorkerOpts } from './lambda-worker.js';
-export { _resetMetricsForTest, getMetrics, type ReviewAgentMetrics } from './metrics.js';
+export {
+  _resetMetricsForTest,
+  bridgeEvalRecordErrorsToMetrics,
+  bridgeFeedbackRateLimitToMetrics,
+  bridgeHistoryReaderErrorsToMetrics,
+  bridgePrunedRowsToMetrics,
+  getMetrics,
+  type ReviewAgentMetrics,
+} from './metrics.js';
 export { type IdempotencyDeps, idempotency } from './middleware/idempotency.js';
 export { type VerifyEnv, verifyGithubSignature } from './middleware/verify-signature.js';
 export {

--- a/packages/server/src/metrics.test.ts
+++ b/packages/server/src/metrics.test.ts
@@ -1,6 +1,13 @@
 import { type Counter, type Histogram, type Meter, metrics } from '@opentelemetry/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { _resetMetricsForTest, getMetrics } from './metrics.js';
+import {
+  _resetMetricsForTest,
+  bridgeEvalRecordErrorsToMetrics,
+  bridgeFeedbackRateLimitToMetrics,
+  bridgeHistoryReaderErrorsToMetrics,
+  bridgePrunedRowsToMetrics,
+  getMetrics,
+} from './metrics.js';
 
 afterEach(() => {
   _resetMetricsForTest();
@@ -35,6 +42,10 @@ describe('getMetrics', () => {
       'review_agent_prompt_injection_blocked_total',
       'review_agent_incremental_skipped_lines_total',
       'review_agent_feedback_command_total',
+      'review_agent_eval_record_errors_total',
+      'review_agent_feedback_rate_limit_drops_total',
+      'review_agent_review_history_pruned_total',
+      'review_agent_history_reader_errors_total',
     ]);
     expect(createHistogram).toHaveBeenCalledWith(
       'review_agent_latency_seconds',
@@ -63,8 +74,8 @@ describe('getMetrics', () => {
     const first = getMetrics(meter);
     const second = getMetrics(meter);
     expect(first).toBe(second);
-    // 7 counters were created on the first call only.
-    expect(createCounter).toHaveBeenCalledTimes(7);
+    // 11 counters were created on the first call only.
+    expect(createCounter).toHaveBeenCalledTimes(11);
   });
 
   it('falls back to the global meter provider when no meter is supplied', () => {
@@ -83,5 +94,64 @@ describe('getMetrics', () => {
     const second = getMetrics(b.meter);
     expect(first).not.toBe(second);
     expect(b.createCounter).toHaveBeenCalled();
+  });
+});
+
+describe('fail-open metric bridges (#106)', () => {
+  it('bridgeEvalRecordErrorsToMetrics increments with provider/model labels', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.evalRecordErrorsTotal, 'add');
+    const bridge = bridgeEvalRecordErrorsToMetrics({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    });
+    bridge(new Error('db outage'));
+    expect(addSpy).toHaveBeenCalledWith(1, {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('bridgeEvalRecordErrorsToMetrics defaults labels to empty strings when none provided', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.evalRecordErrorsTotal, 'add');
+    bridgeEvalRecordErrorsToMetrics()(new Error('x'));
+    expect(addSpy).toHaveBeenCalledWith(1, { provider: '', model: '' });
+  });
+
+  it('bridgeFeedbackRateLimitToMetrics increments unlabelled', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.feedbackRateLimitDropsTotal, 'add');
+    bridgeFeedbackRateLimitToMetrics()();
+    expect(addSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('bridgePrunedRowsToMetrics adds the delete row count for positive ticks', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.reviewHistoryPrunedTotal, 'add');
+    bridgePrunedRowsToMetrics()(42);
+    expect(addSpy).toHaveBeenCalledWith(42);
+  });
+
+  it('bridgePrunedRowsToMetrics suppresses zero-count ticks', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.reviewHistoryPrunedTotal, 'add');
+    bridgePrunedRowsToMetrics()(0);
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('bridgeHistoryReaderErrorsToMetrics increments on every error', () => {
+    const { meter } = fakeMeter();
+    const m = getMetrics(meter);
+    const addSpy = vi.spyOn(m.historyReaderErrorsTotal, 'add');
+    bridgeHistoryReaderErrorsToMetrics()(new Error('reader exploded'));
+    bridgeHistoryReaderErrorsToMetrics()(new Error('again'));
+    expect(addSpy).toHaveBeenCalledTimes(2);
+    expect(addSpy).toHaveBeenNthCalledWith(1, 1);
   });
 });

--- a/packages/server/src/metrics.ts
+++ b/packages/server/src/metrics.ts
@@ -16,6 +16,31 @@ export type ReviewAgentMetrics = {
    * the semantics.
    */
   feedbackCommandTotal: Counter<{ platform: string; kind: string; outcome: string }>;
+  /**
+   * v1.2 #106: fail-open observability counters. All four track
+   * silently-swallowed errors so operators can alert on them; see
+   * `docs/architecture/observability.md` and
+   * `docs/operations/slo-playbook.md`.
+   *
+   * - `evalRecordErrorsTotal{provider, model}`: recorder threw during
+   *   `recordEvalEvent` (typically transient DB / OTel exporter).
+   *   Provider + model are best-effort labels the runner attaches
+   *   when calling the bridge; empty strings are valid.
+   * - `feedbackRateLimitDropsTotal`: `createFeedbackWriter` dropped a
+   *   `FeedbackEvent` because the per-job `maxWritesPerJob` cap was
+   *   reached. spec §7.6.
+   * - `reviewHistoryPrunedTotal`: rows deleted by
+   *   `startReviewHistoryCleanup` (one increment per tick equal to
+   *   the deleted row count). Trend monitoring, not error.
+   * - `historyReaderErrorsTotal`: `historyReader` threw inside the
+   *   runner. The runner re-raises (existing semantic), but the
+   *   counter lets operators alert before the cascading review
+   *   failure surfaces.
+   */
+  evalRecordErrorsTotal: Counter<{ provider: string; model: string }>;
+  feedbackRateLimitDropsTotal: Counter<Record<string, string>>;
+  reviewHistoryPrunedTotal: Counter<Record<string, string>>;
+  historyReaderErrorsTotal: Counter<Record<string, string>>;
   latencySecondsHistogram: Histogram<{ phase: string }>;
 };
 
@@ -46,12 +71,65 @@ export function getMetrics(meter: Meter | null = null): ReviewAgentMetrics {
     feedbackCommandTotal: m.createCounter('review_agent_feedback_command_total', {
       description: '/feedback command outcomes by platform, kind, and outcome (v1.2 #95).',
     }),
+    evalRecordErrorsTotal: m.createCounter('review_agent_eval_record_errors_total', {
+      description: 'recordEvalEvent failures (fail-open). v1.2 #106.',
+    }),
+    feedbackRateLimitDropsTotal: m.createCounter('review_agent_feedback_rate_limit_drops_total', {
+      description: 'FeedbackEvents dropped because maxWritesPerJob was reached. v1.2 #106.',
+    }),
+    reviewHistoryPrunedTotal: m.createCounter('review_agent_review_history_pruned_total', {
+      description: 'Rows deleted by startReviewHistoryCleanup per tick (180-day TTL). v1.2 #106.',
+    }),
+    historyReaderErrorsTotal: m.createCounter('review_agent_history_reader_errors_total', {
+      description: 'historyReader threw inside the runner. v1.2 #106.',
+    }),
     latencySecondsHistogram: m.createHistogram('review_agent_latency_seconds', {
       description: 'End-to-end latency by phase.',
       unit: 's',
     }),
   };
   return cached;
+}
+
+/**
+ * v1.2 #106: default bridges that route the fail-open callbacks
+ * (`onEvalRecordError`, `onRateLimit`, `onPruned`, `onHistoryReaderError`)
+ * to their OTel counters. Operators that want custom behavior can
+ * compose: wrap one of these and add their own log line / additional
+ * counter increment.
+ *
+ * The bridges read `getMetrics()` lazily so they are safe to construct
+ * before the OTel meter provider is wired up (typical at module load).
+ */
+export function bridgeEvalRecordErrorsToMetrics(
+  attrs: { provider?: string; model?: string } = {},
+): (err: unknown) => void {
+  return () => {
+    getMetrics().evalRecordErrorsTotal.add(1, {
+      provider: attrs.provider ?? '',
+      model: attrs.model ?? '',
+    });
+  };
+}
+
+export function bridgeFeedbackRateLimitToMetrics(): () => void {
+  return () => {
+    getMetrics().feedbackRateLimitDropsTotal.add(1);
+  };
+}
+
+export function bridgePrunedRowsToMetrics(): (count: number) => void {
+  return (count) => {
+    if (count > 0) {
+      getMetrics().reviewHistoryPrunedTotal.add(count);
+    }
+  };
+}
+
+export function bridgeHistoryReaderErrorsToMetrics(): (err: unknown) => void {
+  return () => {
+    getMetrics().historyReaderErrorsTotal.add(1);
+  };
 }
 
 // Test helper: drops the cached metrics so the next getMetrics() call

--- a/packages/server/src/worker.test.ts
+++ b/packages/server/src/worker.test.ts
@@ -218,6 +218,57 @@ describe('startReviewHistoryCleanup', () => {
     cleanup.stop();
   });
 
+  it('fires onPruned with the deleted row count when the driver reports rowCount (#106)', async () => {
+    const db = makeDb();
+    const deleteCall = vi.fn().mockResolvedValue({ rowCount: 4 });
+    // biome-ignore lint/suspicious/noExplicitAny: mock surface
+    (db as any).delete = () => ({ where: deleteCall });
+    const onPruned = vi.fn();
+    const cleanup = startReviewHistoryCleanup({
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      db: db as any,
+      intervalMs: 1_000_000,
+      onPruned,
+    });
+    await cleanup.tickOnce();
+    expect(onPruned).toHaveBeenCalledWith(4);
+    cleanup.stop();
+  });
+
+  it('fires onPruned using array length when the driver returns rows directly (#106)', async () => {
+    const db = makeDb();
+    const deleteCall = vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    // biome-ignore lint/suspicious/noExplicitAny: mock surface
+    (db as any).delete = () => ({ where: deleteCall });
+    const onPruned = vi.fn();
+    const cleanup = startReviewHistoryCleanup({
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      db: db as any,
+      intervalMs: 1_000_000,
+      onPruned,
+    });
+    await cleanup.tickOnce();
+    expect(onPruned).toHaveBeenCalledWith(2);
+    cleanup.stop();
+  });
+
+  it('does NOT fire onPruned for zero-count ticks (#106)', async () => {
+    const db = makeDb();
+    const deleteCall = vi.fn().mockResolvedValue({ rowCount: 0 });
+    // biome-ignore lint/suspicious/noExplicitAny: mock surface
+    (db as any).delete = () => ({ where: deleteCall });
+    const onPruned = vi.fn();
+    const cleanup = startReviewHistoryCleanup({
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      db: db as any,
+      intervalMs: 1_000_000,
+      onPruned,
+    });
+    await cleanup.tickOnce();
+    expect(onPruned).not.toHaveBeenCalled();
+    cleanup.stop();
+  });
+
   it('uses a distinct advisory lock key from the idempotency elector', async () => {
     // The two cleanup electors must not serialize on the same key —
     // otherwise webhook_deliveries pruning and review_history pruning

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -123,6 +123,17 @@ export type ReviewHistoryCleanupDeps = {
   readonly db: DbClient;
   readonly intervalMs?: number;
   readonly now?: () => Date;
+  /**
+   * v1.2 #106 observability hook. Fired once per tick with the count
+   * of `review_history` rows actually deleted. Operators wire
+   * `bridgePrunedRowsToMetrics()` from `./metrics.js` to bring this
+   * into `review_agent_review_history_pruned_total`.
+   *
+   * Zero-count ticks (no rows expired, or this worker was not the
+   * advisory-lock leader for this tick) do NOT fire the callback so
+   * a no-op operator hook does not need a guard.
+   */
+  readonly onPruned?: (deletedRowCount: number) => void;
 };
 
 /**
@@ -148,7 +159,17 @@ export function startReviewHistoryCleanup(deps: ReviewHistoryCleanupDeps): Clean
     const lockHeld = await tryAcquireLock(deps.db, REVIEW_HISTORY_CLEANUP_LOCK_KEY);
     if (!lockHeld) return;
     try {
-      await deps.db.delete(reviewHistory).where(lt(reviewHistory.expiresAt, now()));
+      const result = await deps.db.delete(reviewHistory).where(lt(reviewHistory.expiresAt, now()));
+      // The postgres-js driver surfaces deleted row count as
+      // `rowCount`; some drivers/adapters use array length instead.
+      // Drivers wrapped in `db.execute` may resolve to `undefined` when
+      // no row-count tracking is wired. Mirror the fallback in
+      // `@review-agent/db/review-history.ts` so both shapes are
+      // tolerated, and degrade silently when the driver gives us
+      // neither (treat as 0).
+      const r = (result ?? {}) as { rowCount?: number; length?: number };
+      const deleted = r.rowCount ?? r.length ?? 0;
+      if (deleted > 0) deps.onPruned?.(deleted);
     } finally {
       await releaseLock(deps.db, REVIEW_HISTORY_CLEANUP_LOCK_KEY);
     }


### PR DESCRIPTION
## Summary

post-v1.2 wave B の 8 件を `develop` から `main` へ。前 wave (PR #109、Closes #95/#99/#101/#104) の残りタスクで、Refined だったもの + #105 を本 wave で refine + 実装。

| # | スコープ | 種別 |
|---|---|---|
| **#96** | `<!-- fingerprint:<fp> -->` 埋め込み (core helper + 2 adapter) — #95 marker (a) path を有効化 | feat |
| **#106** | OTel 4 counter (`eval_record_errors` / `feedback_rate_limit_drops` / `review_history_pruned` / `history_reader_errors`) + 4 bridge factory + 新 hook (`onPruned` / `onHistoryReaderError`) | feat |
| **#100** | `UPGRADING.md` に v1.1 → v1.2 章 (9 サブセクション、DB migration / 新 deps / 新 config / CodeCommit parity status / 等) | docs |
| **#103** | `docs/operations/review_eval_event-playbook.md` (7 SQL レシピ + RLS 注意 + cross-tenant superuser パターン) | docs |
| **#98** | `docs/operations/v1-2-worker-example.md` (Lambda + SQS の TS フル reference) + 3 architecture doc 相互リンク | docs |
| **#107** | `packages/db/src/__tests__/migration-compat.integration.test.ts` 4 ケース (forward-compat 保証) | test |
| **#108** | `packages/runner/src/__tests__/self-feedback-loop.test.ts` 3 ケース (`[fp:<fp>]` プレフィックス protocol roundtrip) | test |
| **#105** | `recover review-eval-events` + `recover feedback-history` CLI (GitHub のみ) + db helper + tests + 4 件の Locked design decisions | feat |

#105 は refine 過程で **CodeCommit `/feedback` re-scrape を新 issue [#110](https://github.com/almondoo/review-agent/issues/110) として切り出し** — CodeCommit adapter の PR comment ページング読み出しが未実装で、本 wave の scope から独立しているため。

## Verification

`pnpm typecheck && lint && test:coverage && build` green。

- typecheck: 12 packages Done
- lint (Biome 2.x): 417 files clean
- test: **1385 passed + 11 skipped** (DB integration; \`TEST_DATABASE_APP_URL\` で unlock)
- build: ESM + CJS + .d.ts × 12 packages

## Test plan

- [x] root \`pnpm typecheck && lint && test:coverage && build\` green
- [x] \`packages/core\`: 281 tests (+12 for `comment-fingerprint`)
- [x] \`packages/runner\`: 361 tests (+4 for #96 resolver alias / #106 onHistoryReaderError / #108 round-trip)
- [x] \`packages/server\`: 202 tests (+10 for #106 bridges + onPruned)
- [x] \`packages/cli\`: 88 tests (+6 for #105 recover subcommands)
- [x] \`packages/platform-github\` / \`platform-codecommit\`: +1 each for #96 marker append
- [ ] (post-merge) integration tests run with TEST_DATABASE_APP_URL set in CI (#107 4 ケース、existing integration tests も継続 green)
- [ ] (post-merge) CodeCommit テナント運用者が `/feedback` 経由で marker resolver を動作確認 (#96 + #95 marker (a) path)
- [ ] (post-merge) #110 を refine して着手 (CodeCommit /feedback re-scrape、#105 で reject されている)

Closes #96
Closes #98
Closes #100
Closes #103
Closes #105
Closes #106
Closes #107
Closes #108