### PR TITLE
fix(cli): #113 close CodeCommit /feedback recovery allowlist bypass

### DIFF
--- a/.changeset/issue-113-codecommit-recovery-authz.md
+++ b/.changeset/issue-113-codecommit-recovery-authz.md
@@ -1,0 +1,27 @@
+---
+'@review-agent/platform-codecommit': patch
+'@review-agent/server': patch
+'@review-agent/cli': patch
+'@review-agent/db': patch
+---
+
+#113 — CodeCommit `/feedback` recovery: apply allowlist to reply authors
+
+The disaster-recovery CLI `review-agent recover feedback-history --platform codecommit` (added in #110) previously checked only the parent comment's author against `--bot-arn` — the reply author was never inspected against `REVIEW_AGENT_FEEDBACK_ALLOWLIST`. An attacker with `codecommit:PostCommentForPullRequest` whose live `/feedback` replies were denied could therefore have those replies silently re-promoted into `review_history` the next time the operator ran the recovery CLI, biasing future `<learned_facts>` and suppressing real findings via the dedup middleware.
+
+**@review-agent/platform-codecommit**
+
+- New `authz.ts` module — `checkCodeCommitFeedbackAuthz`, `parseAllowlist`, fail-closed semantics — lifted from `@review-agent/server` so the recovery CLI can apply the same check.
+
+**@review-agent/server**
+
+- `feedback-authz.ts` now re-exports the CodeCommit authz from `@review-agent/platform-codecommit`. Public surface unchanged.
+
+**@review-agent/cli**
+
+- `scrapeCodeCommitFeedback` now requires `feedbackAllowlist: readonly string[]` and rejects replies whose author ARN is not on the allowlist (or is missing). Stats gain an `unauthorized` counter, surfaced in the run summary.
+- `recover feedback-history --platform codecommit` reads `REVIEW_AGENT_FEEDBACK_ALLOWLIST` from the environment, mirroring the live webhook. An unset / empty allowlist emits a stderr warning and fails closed.
+
+**@review-agent/db**
+
+- Widened `RecoverFeedbackHistoryResult.status` to `'ok' | 'partial'` so the CodeCommit recovery CLI can surface allowlist-denied / fail-closed runs as non-zero exit status (#113 fix). No runtime behaviour change; type-level additive change.

--- a/docs/operations/codecommit-disaster-recovery.md
+++ b/docs/operations/codecommit-disaster-recovery.md
@@ -260,7 +260,9 @@ DATABASE_URL=... review-agent recover feedback-history \
 #     its parent Bot comment via inReplyTo and #96's fingerprint
 #     marker. Unresolved /feedback (no inReplyTo, parent authored
 #     by a non-Bot principal, or parent has no marker — typically
-#     pre-#96 comments) are skipped and counted.
+#     pre-#96 comments) are skipped and counted. Allowlist-denied
+#     replies are counted separately under `unauthorized` (see the
+#     SECURITY block below).
 #     IAM: requires codecommit:ListPullRequests in addition to the
 #     standard worker permissions.
 #
@@ -271,6 +273,17 @@ DATABASE_URL=... review-agent recover feedback-history \
 #       review_history by self-replying /feedback to a hand-crafted
 #       parent comment. Use the IAM role / user ARN that posts Bot
 #       comments through PostCommentForPullRequest.
+#
+#       --feedback-allowlist via env (NEW v1.2 #113):
+#        REVIEW_AGENT_FEEDBACK_ALLOWLIST must be set to the same CSV of
+#        IAM principal ARNs the live webhook consults
+#        (packages/server/src/handlers/codecommit-webhook.ts:347-351).
+#        Replies whose author ARN is not on the allowlist — or whose
+#        author ARN is missing — are counted under `unauthorized` in
+#        the run summary and NEVER promoted into review_history. This
+#        closes the gap where #110's recovery walk silently re-promoted
+#        replies that the live webhook would have denied. Fail-closed:
+#        an unset / empty env counts every reply as unauthorized.
 #
 #       --repo accepts `<name>` or `<owner>/<name>`. Regardless of
 #       the operator-supplied owner prefix, the DB key is always
@@ -283,6 +296,7 @@ DATABASE_URL=... review-agent recover feedback-history \
 #
 #       --pr is parsed strictly; `--pr 100abc` is rejected up-front
 #       rather than silently coerced to 100.
+REVIEW_AGENT_FEEDBACK_ALLOWLIST='arn1,arn2' \
 AWS_REGION=... DATABASE_URL=... review-agent recover feedback-history \
   --installation-id <id> \
   --repo <repository-name> \

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -372,6 +372,7 @@ open question 解決済みで「issue を読んで即着手」できる状態。
 | [#96](https://github.com/almondoo/review-agent/issues/96) | fingerprint embedding in posted PR comments (#95 marker 経路の前提) | — |
 | [#105](https://github.com/almondoo/review-agent/issues/105) | recover-sync-state v1.2 mirror reconciliation (CodeCommit) | — |
 | [#106](https://github.com/almondoo/review-agent/issues/106) | OTel metrics for fail-open events | — |
+| [#113](https://github.com/almondoo/review-agent/issues/113) | CodeCommit `/feedback` recovery: allowlist gate on reply author (#110 hardening) | ✅ |
 
 ### Docs
 

--- a/docs/security/feedback-command-authz.md
+++ b/docs/security/feedback-command-authz.md
@@ -31,7 +31,7 @@ asymmetry.
 | Platform | Check |
 |---|---|
 | **GitHub** | `octokit.rest.repos.getCollaboratorPermissionLevel({owner, repo, username})` → `permission ∈ {'admin', 'maintain', 'write'}`. `read` and `triage` are denied. |
-| **CodeCommit** | CSV allowlist in `REVIEW_AGENT_FEEDBACK_ALLOWLIST` env, matched against the SNS event's `userIdentity.principalId`. |
+| **CodeCommit** | CSV allowlist in `REVIEW_AGENT_FEEDBACK_ALLOWLIST` env, matched against the SNS event's `userIdentity.principalId`. Same allowlist gates `review-agent recover feedback-history --platform codecommit` (v1.2 #113); recovery cannot re-promote replies that the live webhook would have denied. |
 
 `'admin'`, `'maintain'`, `'write'` are GitHub's three "push-equivalent"
 permission tiers — they correspond to `repos.pushedToBranch`

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -1278,6 +1278,15 @@ const octokit = new Octokit({ auth: token });
   numeric AWS account id for the empty owner segment so each tenant's
   rows are uniquely keyed even when multiple installations share a
   repo name across accounts.
+- `REVIEW_AGENT_FEEDBACK_ALLOWLIST` gates both the live `/feedback`
+  webhook (codecommit-webhook.ts) AND the disaster-recovery CLI
+  (`review-agent recover feedback-history --platform codecommit`,
+  v1.2 #110). Recovery uses the same fail-closed semantics: an
+  unset / empty allowlist counts every reply as `unauthorized` and
+  none is promoted into `review_history`. This closes the gap
+  surfaced by v1.2 #113 where the recovery walk previously checked
+  only the parent comment's author, not the `/feedback` reply
+  author. See `docs/security/feedback-command-authz.md`.
 
 ### 8.5 BYOK (Anthropic API key)
 

--- a/packages/cli/src/commands/recover-codecommit-feedback.test.ts
+++ b/packages/cli/src/commands/recover-codecommit-feedback.test.ts
@@ -77,6 +77,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(1);
@@ -116,6 +117,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     // feedbackKindToFactType collapses thumbs_down + dismissed into
@@ -138,6 +140,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(0);
@@ -163,6 +166,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(0);
@@ -207,6 +211,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sinceDate: new Date('2026-05-10T00:00:00Z'),
       sleep: async () => undefined,
     });
@@ -235,6 +240,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       onlyPr: 101,
       sleep: async () => undefined,
     });
@@ -259,6 +265,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     // parseFeedbackKind returns null → the command is not counted as
@@ -278,6 +285,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       pullRequestStatus: 'OPEN',
       sleep: async () => undefined,
     });
@@ -298,6 +306,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep,
       delayMs: 250,
     });
@@ -342,6 +351,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(0);
@@ -382,6 +392,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sinceDate: new Date('2026-05-10T00:00:00Z'),
       sleep: async () => undefined,
     });
@@ -413,6 +424,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(0);
@@ -450,6 +462,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(0);
@@ -484,6 +497,7 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
       client,
       repositoryName: 'demo',
       botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
       sleep: async () => undefined,
     });
     expect(result.candidates).toHaveLength(1);
@@ -492,5 +506,116 @@ describe('scrapeCodeCommitFeedback (#110)', () => {
     expect(factText).toBe(`[fp:${fp}] codecommit-recover dismissed at ${ts.toISOString()}`);
     expect(factText.includes('ignore previous instructions')).toBe(false);
     expect(factText.includes('AKIA')).toBe(false);
+  });
+});
+
+describe('scrapeCodeCommitFeedback (#113 allowlist gate)', () => {
+  const buildResolvableSeed = () => {
+    const fp = fingerprint({
+      path: 'src/h.ts',
+      line: 1,
+      ruleId: 'sql-injection',
+      suggestionType: 'comment',
+    });
+    return {
+      fp,
+      seed: {
+        prIds: ['51'],
+        commentsByPr: {
+          '51': [
+            {
+              commentId: 'p',
+              content: appendFingerprintMarker('finding', fp),
+              authorArn: BOT_ARN,
+              creationDate: new Date('2026-05-01T00:00:00Z'),
+            },
+            {
+              commentId: 'fb',
+              content: '/feedback reject',
+              inReplyTo: 'p',
+              authorArn: OTHER_ARN,
+              creationDate: new Date('2026-05-02T00:00:00Z'),
+            },
+          ],
+        },
+      },
+    };
+  };
+
+  it('records the reply when the author is on the allowlist', async () => {
+    const { seed } = buildResolvableSeed();
+    const client = makeClient(seed);
+    const result = await scrapeCodeCommitFeedback({
+      client,
+      repositoryName: 'demo',
+      botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN],
+      sleep: async () => undefined,
+    });
+    expect(result.candidates).toHaveLength(1);
+    expect(result.stats.unauthorized).toBe(0);
+  });
+
+  it('counts the reply as unauthorized (not recorded) when the author is not on the allowlist', async () => {
+    const { seed } = buildResolvableSeed();
+    const client = makeClient(seed);
+    const result = await scrapeCodeCommitFeedback({
+      client,
+      repositoryName: 'demo',
+      botArn: BOT_ARN,
+      feedbackAllowlist: ['arn:aws:iam::123456789012:user/eve'],
+      sleep: async () => undefined,
+    });
+    expect(result.candidates).toHaveLength(0);
+    expect(result.stats.unauthorized).toBe(1);
+    expect(result.stats.unresolved).toBe(0);
+    expect(result.stats.feedbackCommandsSeen).toBe(1);
+  });
+
+  it('counts the reply as unauthorized when authorArn is missing (fail-closed)', async () => {
+    const fp = fingerprint({
+      path: 'src/i.ts',
+      line: 1,
+      ruleId: 'sql-injection',
+      suggestionType: 'comment',
+    });
+    const client = makeClient({
+      prIds: ['53'],
+      commentsByPr: {
+        '53': [
+          {
+            commentId: 'p',
+            content: appendFingerprintMarker('finding', fp),
+            authorArn: BOT_ARN,
+          },
+          // Reply omits authorArn entirely. Fail-closed: treat as
+          // unauthorized rather than as a valid /feedback signal.
+          { commentId: 'fb', content: '/feedback reject', inReplyTo: 'p' },
+        ],
+      },
+    });
+    const result = await scrapeCodeCommitFeedback({
+      client,
+      repositoryName: 'demo',
+      botArn: BOT_ARN,
+      feedbackAllowlist: [OTHER_ARN], // would allow OTHER_ARN, but reply has no authorArn
+      sleep: async () => undefined,
+    });
+    expect(result.candidates).toHaveLength(0);
+    expect(result.stats.unauthorized).toBe(1);
+  });
+
+  it('fails closed when the allowlist is empty (every reply counted as unauthorized)', async () => {
+    const { seed } = buildResolvableSeed();
+    const client = makeClient(seed);
+    const result = await scrapeCodeCommitFeedback({
+      client,
+      repositoryName: 'demo',
+      botArn: BOT_ARN,
+      feedbackAllowlist: [], // unset env path
+      sleep: async () => undefined,
+    });
+    expect(result.candidates).toHaveLength(0);
+    expect(result.stats.unauthorized).toBe(1);
   });
 });

--- a/packages/cli/src/commands/recover-codecommit-feedback.ts
+++ b/packages/cli/src/commands/recover-codecommit-feedback.ts
@@ -7,6 +7,7 @@ import type { RecoverFeedbackHistoryCandidate } from '@review-agent/db';
 import {
   type CodeCommitClientLike,
   type CodeCommitRawComment,
+  checkCodeCommitFeedbackAuthz,
   listCodeCommitCommentsForPullRequest,
   listCodeCommitPullRequestIds,
 } from '@review-agent/platform-codecommit';
@@ -49,6 +50,18 @@ export type ScrapeCodeCommitFeedbackOpts = {
    * marker and laundering it into `review_history`.
    */
   readonly botArn: string;
+  /**
+   * v1.2 #113: operator-managed allowlist of IAM principal ARNs whose
+   * `/feedback` replies are recoverable. Mirrors the runtime webhook
+   * gate (`packages/server/src/handlers/codecommit-webhook.ts:347-365`)
+   * so that recovery cannot silently re-promote replies that the live
+   * authz check would have denied.
+   *
+   * Fail-closed: an empty array denies every reply (treated as
+   * `unauthorized`). The CLI layer is responsible for parsing
+   * `REVIEW_AGENT_FEEDBACK_ALLOWLIST` (CSV) into this array.
+   */
+  readonly feedbackAllowlist: ReadonlyArray<string>;
   readonly pullRequestStatus?: 'OPEN' | 'CLOSED' | 'ALL';
   readonly sinceDate?: Date;
   readonly onlyPr?: number;
@@ -63,6 +76,14 @@ export type ScrapeCodeCommitFeedbackResult = {
     readonly commentsSeen: number;
     readonly feedbackCommandsSeen: number;
     readonly unresolved: number;
+    /**
+     * v1.2 #113: `/feedback` replies whose author ARN is not on
+     * `feedbackAllowlist` (or whose `authorArn` is undefined — also
+     * fail-closed). Tracked separately from `unresolved` so the
+     * operator can distinguish missing/malformed data from
+     * security-denied attempts.
+     */
+    readonly unauthorized: number;
     readonly resolved: number;
   };
 };
@@ -121,6 +142,7 @@ export async function scrapeCodeCommitFeedback(
   let commentsSeen = 0;
   let feedbackCommandsSeen = 0;
   let unresolved = 0;
+  let unauthorized = 0;
   const candidates: RecoverFeedbackHistoryCandidate[] = [];
 
   for (const prId of prIds) {
@@ -162,6 +184,20 @@ export async function scrapeCodeCommitFeedback(
         unresolved += 1;
         continue;
       }
+      // v1.2 #113: gate the reply author against the same allowlist
+      // the live webhook (codecommit-webhook.ts:347-351) consults.
+      // Without this, an attacker whose webhook /feedback replies
+      // were denied at runtime can still get them silently promoted
+      // into review_history when the operator runs the recovery CLI.
+      // Fail-closed on missing authorArn (treat as unauthorized).
+      const authz = checkCodeCommitFeedbackAuthz({
+        principalId: c.authorArn ?? '',
+        allowlistEnv: opts.feedbackAllowlist.join(','),
+      });
+      if (!authz.allowed) {
+        unauthorized += 1;
+        continue;
+      }
       const fp = extractFingerprintFromComment(parent.content);
       if (!fp) {
         unresolved += 1;
@@ -192,6 +228,7 @@ export async function scrapeCodeCommitFeedback(
       commentsSeen,
       feedbackCommandsSeen,
       unresolved,
+      unauthorized,
       resolved: candidates.length,
     },
   };

--- a/packages/cli/src/commands/recover.test.ts
+++ b/packages/cli/src/commands/recover.test.ts
@@ -1,4 +1,9 @@
-import type { ReviewState, VCS } from '@review-agent/core';
+import {
+  appendFingerprintMarker,
+  fingerprint,
+  type ReviewState,
+  type VCS,
+} from '@review-agent/core';
 import { describe, expect, it, vi } from 'vitest';
 import {
   recoverFeedbackHistoryCommand,
@@ -436,6 +441,231 @@ describe('recoverFeedbackHistoryCommand (#105)', () => {
     expect(result.candidates).toBe(0);
     expect(io.err.join('')).toContain('--since must be');
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it('--platform codecommit warns when REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset (#113 fail-closed)', async () => {
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    const codecommitClient = {
+      send: vi.fn(async (cmd: { constructor: { name: string } }) => {
+        if (cmd.constructor.name === 'ListPullRequestsCommand') {
+          return { pullRequestIds: [] };
+        }
+        throw new Error(`Unmocked SDK command: ${cmd.constructor.name}`);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed SDK client
+    } as any;
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'review-agent',
+      installationId: 1n,
+      // No REVIEW_AGENT_FEEDBACK_ALLOWLIST in env → fail-closed warning path.
+      env: { DATABASE_URL: 'postgres://x' } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      botArn: 'arn:aws:iam::1:role/review-agent-bot',
+      dryRun: true,
+      codecommitClient,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    expect(result.status).toBe('ok');
+    expect(io.err.join('')).toContain('REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset');
+    // Run summary now carries the new `unauthorized` counter.
+    expect(io.out.join('')).toContain('0 unauthorized (denied by allowlist)');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('--platform codecommit does NOT warn when REVIEW_AGENT_FEEDBACK_ALLOWLIST is set (#113)', async () => {
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    const codecommitClient = {
+      send: vi.fn(async (cmd: { constructor: { name: string } }) => {
+        if (cmd.constructor.name === 'ListPullRequestsCommand') {
+          return { pullRequestIds: [] };
+        }
+        throw new Error(`Unmocked SDK command: ${cmd.constructor.name}`);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed SDK client
+    } as any;
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'review-agent',
+      installationId: 1n,
+      env: {
+        DATABASE_URL: 'postgres://x',
+        REVIEW_AGENT_FEEDBACK_ALLOWLIST: 'arn:aws:iam::1:user/alice',
+      } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      botArn: 'arn:aws:iam::1:role/review-agent-bot',
+      dryRun: true,
+      codecommitClient,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    expect(result.status).toBe('ok');
+    expect(io.err.join('')).not.toContain('REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('--platform codecommit downgrades status to partial when allowlist denies a reply (#113)', async () => {
+    // Seed a /feedback reply whose parent has a valid marker + Bot ARN,
+    // but the reply's authorArn is NOT on REVIEW_AGENT_FEEDBACK_ALLOWLIST.
+    // The scrape should count it under `unauthorized`, surface the
+    // 'partial' status to operators (so cron callers branching on `$?`
+    // detect the silent deny), and emit the new note line on stdout.
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    const BOT_ARN = 'arn:aws:iam::1:role/review-agent-bot';
+    const EVE_ARN = 'arn:aws:iam::1:user/eve';
+    const ALICE_ARN = 'arn:aws:iam::1:user/alice';
+    const fp = fingerprint({
+      path: 'src/a.ts',
+      line: 1,
+      ruleId: 'sql-injection',
+      suggestionType: 'comment',
+    });
+    const codecommitClient = {
+      send: vi.fn(async (cmd: { constructor: { name: string }; input?: unknown }) => {
+        const name = cmd.constructor.name;
+        if (name === 'ListPullRequestsCommand') {
+          return { pullRequestIds: ['7'] };
+        }
+        if (name === 'GetCommentsForPullRequestCommand') {
+          return {
+            commentsForPullRequestData: [
+              {
+                comments: [
+                  {
+                    commentId: 'parent',
+                    content: appendFingerprintMarker('finding', fp),
+                    authorArn: BOT_ARN,
+                    creationDate: new Date('2026-05-01T00:00:00Z'),
+                  },
+                  {
+                    commentId: 'reply',
+                    content: '/feedback reject',
+                    inReplyTo: 'parent',
+                    authorArn: EVE_ARN, // NOT on allowlist
+                    creationDate: new Date('2026-05-02T00:00:00Z'),
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        throw new Error(`Unmocked SDK command: ${name}`);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed SDK client
+    } as any;
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'review-agent',
+      installationId: 1n,
+      env: {
+        DATABASE_URL: 'postgres://x',
+        REVIEW_AGENT_FEEDBACK_ALLOWLIST: ALICE_ARN,
+      } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      botArn: BOT_ARN,
+      dryRun: true,
+      codecommitClient,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    // The scrape stats reach stdout in the summary line.
+    expect(io.out.join('')).toContain('1 unauthorized (denied by allowlist)');
+    // The new note line is appended after the summary.
+    expect(io.out.join('')).toContain(
+      "REVIEW_AGENT_FEEDBACK_ALLOWLIST; run status reported as 'partial'",
+    );
+    // Status downgraded so `program.ts` can exit non-zero.
+    expect(result.status).toBe('partial');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('--platform codecommit downgrades to partial when allowlist is unset and /feedback commands were seen but unauthorized=0 (#113 second-arm)', async () => {
+    // Drives the second `else if` arm of the partial-downgrade trigger
+    // (allowlist unset + feedbackCommandsSeen > 0) with `unauthorized === 0`.
+    // The reply bumps `feedbackCommandsSeen++` at the top of the loop in
+    // `scrapeCodeCommitFeedback` and then exits via the `parentId === undefined`
+    // gate, so it never reaches the authz check — `unauthorized` stays at 0.
+    // The new branch-specific note line must mention the unset-env condition
+    // and NOT the misleading "0 reply/replies were denied" wording.
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    const BOT_ARN = 'arn:aws:iam::1:role/review-agent-bot';
+    const codecommitClient = {
+      send: vi.fn(async (cmd: { constructor: { name: string }; input?: unknown }) => {
+        const name = cmd.constructor.name;
+        if (name === 'ListPullRequestsCommand') {
+          return { pullRequestIds: ['9'] };
+        }
+        if (name === 'GetCommentsForPullRequestCommand') {
+          return {
+            commentsForPullRequestData: [
+              {
+                comments: [
+                  {
+                    commentId: 'orphan',
+                    content: '/feedback reject',
+                    // No `inReplyTo` → exits early via the `parentId === undefined`
+                    // gate, after the `feedbackCommandsSeen++` increment.
+                    authorArn: 'arn:aws:iam::1:user/anyone',
+                    creationDate: new Date('2026-05-02T00:00:00Z'),
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        throw new Error(`Unmocked SDK command: ${name}`);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed SDK client
+    } as any;
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'review-agent',
+      installationId: 1n,
+      // REVIEW_AGENT_FEEDBACK_ALLOWLIST intentionally unset.
+      env: { DATABASE_URL: 'postgres://x' } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      botArn: BOT_ARN,
+      dryRun: true,
+      codecommitClient,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    // Stats: command was seen but never reached the authz gate.
+    expect(io.out.join('')).toContain('1 /feedback commands found');
+    expect(io.out.join('')).toContain('0 unauthorized (denied by allowlist)');
+    // New branch-specific note: must mention the unset-env condition AND the
+    // observed feedback-command count, NOT the misleading "denied by allowlist"
+    // wording that the first arm uses.
+    expect(io.out.join('')).toContain('REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset');
+    expect(io.out.join('')).toContain('1 /feedback command(s) were seen');
+    expect(io.out.join('')).not.toContain('0 reply/replies were denied');
+    expect(result.status).toBe('partial');
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('--rate Infinity warns and falls back to the 500ms default (codecommit)', async () => {

--- a/packages/cli/src/commands/recover.ts
+++ b/packages/cli/src/commands/recover.ts
@@ -284,6 +284,12 @@ export async function recoverFeedbackHistoryCommand(
   // Source candidates either from a JSONL file (GitHub) or from a
   // direct CodeCommit `/feedback` re-scrape (#110).
   let candidates: ReadonlyArray<RecoverFeedbackHistoryCandidate>;
+  // v1.2 #113: the codecommit branch may surface denied / silently
+  // skipped replies — when it does we downgrade the returned status
+  // to `'partial'` so operators running from cron and checking only
+  // `$?` get a distinct signal from a clean "no feedback" run.
+  // The GitHub branch leaves this `false` (no allowlist gate runs).
+  let downgradeToPartial = false;
   // Default DB key matches the GitHub convention (`owner/repo`). The
   // CodeCommit branch overrides this with `${installationId}/${repoName}`
   // — a wrong-account `--repo wrong/foo` therefore cannot shadow the
@@ -341,10 +347,24 @@ export async function recoverFeedbackHistoryCommand(
         );
       }
     }
+    const feedbackAllowlistRaw = opts.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST ?? '';
+    const feedbackAllowlist = feedbackAllowlistRaw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (feedbackAllowlist.length === 0) {
+      io.stderr(
+        'warning: REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset; every recovered ' +
+          '/feedback reply will be counted as unauthorized (fail-closed). ' +
+          'Set the env to the same CSV used by the live webhook to recover ' +
+          'authorized replies.\n',
+      );
+    }
     const scrape = await scrapeCodeCommitFeedback({
       client,
       repositoryName: repoName,
       botArn: opts.botArn,
+      feedbackAllowlist,
       ...(sinceDate ? { sinceDate } : {}),
       ...(opts.onlyPr !== undefined ? { onlyPr: opts.onlyPr } : {}),
       delayMs,
@@ -354,8 +374,37 @@ export async function recoverFeedbackHistoryCommand(
       `codecommit re-scrape: walked ${scrape.stats.prsWalked} PR(s), ` +
         `${scrape.stats.commentsSeen} comments, ` +
         `${scrape.stats.feedbackCommandsSeen} /feedback commands found, ` +
-        `${scrape.stats.resolved} resolved, ${scrape.stats.unresolved} unresolved (skipped).\n`,
+        `${scrape.stats.resolved} resolved, ${scrape.stats.unresolved} unresolved (skipped), ` +
+        `${scrape.stats.unauthorized} unauthorized (denied by allowlist).\n`,
     );
+    // v1.2 #113: surface `'partial'` for two distinct conditions so cron
+    // callers checking `$?` get a non-zero exit:
+    //   (1) `unauthorized > 0` — the allowlist rejected at least one
+    //       reply that actually reached the authz gate. This is the
+    //       direct security signal: replies that would have landed in
+    //       review_history under #110's old behaviour did not.
+    //   (2) `feedbackAllowlist.length === 0 && feedbackCommandsSeen > 0`
+    //       — `REVIEW_AGENT_FEEDBACK_ALLOWLIST` is unset and the scrape
+    //       observed at least one `/feedback` command. Even when every
+    //       command exited via an earlier gate (and `unauthorized` is 0),
+    //       the run is treated as `'partial'` because the operator's
+    //       cron-time configuration is incomplete and a future re-run
+    //       with the env set could recover authorized replies. The two
+    //       arms are independent; (2) is NOT a superset of (1).
+    if (scrape.stats.unauthorized > 0) {
+      downgradeToPartial = true;
+      io.stdout(
+        `note: ${scrape.stats.unauthorized} reply/replies were denied by ` +
+          `REVIEW_AGENT_FEEDBACK_ALLOWLIST; run status reported as 'partial'.\n`,
+      );
+    } else if (feedbackAllowlist.length === 0 && scrape.stats.feedbackCommandsSeen > 0) {
+      downgradeToPartial = true;
+      io.stdout(
+        `note: REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset and ` +
+          `${scrape.stats.feedbackCommandsSeen} /feedback command(s) were seen; ` +
+          `run status reported as 'partial' (set the env to recover authorized replies).\n`,
+      );
+    }
   } else {
     if (!opts.candidatesFile) {
       io.stderr('recover feedback-history --platform github requires --candidates-file <path>.\n');
@@ -383,7 +432,11 @@ export async function recoverFeedbackHistoryCommand(
         (opts.dryRun ? ' (dry-run; no inserts)' : '') +
         '\n',
     );
-    return result;
+    // v1.2 #113: see `downgradeToPartial` rationale upstream. The
+    // helper itself only ever returns 'ok'; we layer the partial
+    // status here so operators get a non-zero exit signal when the
+    // codecommit branch denied any reply.
+    return downgradeToPartial ? { ...result, status: 'partial' } : result;
   } finally {
     await close();
   }

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { appendFingerprintMarker, fingerprint } from '@review-agent/core';
+import { describe, expect, it, vi } from 'vitest';
+import { recoverFeedbackHistoryCommand } from './commands/recover.js';
 import { buildProgram } from './program.js';
 
 function recordingIo() {
@@ -529,6 +531,96 @@ describe('buildProgram', () => {
     await expect(() => program.parseAsync(['--version'], { from: 'user' })).rejects.toMatchObject({
       code: 'commander.version',
     });
+  });
+
+  it('recover feedback-history partial status maps to io.exit(1) (#113)', async () => {
+    // Pins the load-bearing seam at program.ts:336-337 —
+    //   `io.exit(result.status === 'partial' ? 1 : 0)` —
+    // which is the actual `$?` cron callers observe. The line carries a
+    // `/* v8 ignore next */` directive so its branch is not counted in
+    // coverage; this test closes the loop end-to-end at the
+    // helper→exit-code boundary.
+    //
+    // Approach: INLINE FALLBACK. The program.ts action callback at
+    // lines 315-338 constructs `createDefaultCodeCommitClient()`
+    // directly and does not accept a `codecommitClient` / `createDb`
+    // seam in `RecoverFeedbackHistoryCliOpts`, so a `parseAsync(...)`
+    // path cannot reach the partial branch without either (a) live AWS
+    // credentials + a real CodeCommit repo or (b) widening
+    // `RecoverFeedbackHistoryCliOpts` with new test-only public seams.
+    // Both are out of scope for a test-only assertion; we drive the
+    // helper directly with the same partial-trigger fixture used in
+    // `recover.test.ts` and then apply the exact ternary the program
+    // action runs.
+    const io = recordingIo();
+    const close = vi.fn(async () => undefined);
+    const BOT_ARN = 'arn:aws:iam::1:role/review-agent-bot';
+    const EVE_ARN = 'arn:aws:iam::1:user/eve';
+    const ALICE_ARN = 'arn:aws:iam::1:user/alice';
+    const fp = fingerprint({
+      path: 'src/a.ts',
+      line: 1,
+      ruleId: 'sql-injection',
+      suggestionType: 'comment',
+    });
+    const codecommitClient = {
+      send: vi.fn(async (cmd: { constructor: { name: string } }) => {
+        const name = cmd.constructor.name;
+        if (name === 'ListPullRequestsCommand') {
+          return { pullRequestIds: ['7'] };
+        }
+        if (name === 'GetCommentsForPullRequestCommand') {
+          return {
+            commentsForPullRequestData: [
+              {
+                comments: [
+                  {
+                    commentId: 'parent',
+                    content: appendFingerprintMarker('finding', fp),
+                    authorArn: BOT_ARN,
+                    creationDate: new Date('2026-05-01T00:00:00Z'),
+                  },
+                  {
+                    commentId: 'reply',
+                    content: '/feedback reject',
+                    inReplyTo: 'parent',
+                    authorArn: EVE_ARN, // NOT on allowlist → unauthorized
+                    creationDate: new Date('2026-05-02T00:00:00Z'),
+                  },
+                ],
+              },
+            ],
+          };
+        }
+        throw new Error(`Unmocked SDK command: ${name}`);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed SDK client
+    } as any;
+    const fakeDb = {
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(fakeDb),
+      execute: vi.fn(async () => []),
+      select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+      insert: () => ({ values: vi.fn(async () => undefined) }),
+    };
+    const result = await recoverFeedbackHistoryCommand(io, {
+      repo: 'review-agent',
+      installationId: 1n,
+      env: {
+        DATABASE_URL: 'postgres://x',
+        REVIEW_AGENT_FEEDBACK_ALLOWLIST: ALICE_ARN,
+      } as NodeJS.ProcessEnv,
+      platform: 'codecommit',
+      botArn: BOT_ARN,
+      dryRun: true,
+      codecommitClient,
+      // biome-ignore lint/suspicious/noExplicitAny: stubbed DB client
+      createDb: () => ({ db: fakeDb as any, close }),
+    });
+    expect(result.status).toBe('partial');
+    // Inline replay of program.ts:336-337 — verifies the exact ternary
+    // wiring against the helper's partial output.
+    io.exit(result.status === 'partial' ? 1 : 0);
+    expect(io.exitCode).toBe(1);
   });
 
   it('uses process.env when no env is supplied (deps.env ?? process.env)', async () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -313,7 +313,7 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
     )
     .option('--dry-run', 'count candidates vs existing rows but do not insert', false)
     .action(async (opts: RecoverFeedbackHistoryCliOpts) => {
-      await recoverFeedbackHistoryCommand(io, {
+      const result = await recoverFeedbackHistoryCommand(io, {
         repo: opts.repo,
         installationId: opts.installationId,
         platform: opts.platform,
@@ -327,7 +327,14 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
         /* v8 ignore next */
         dryRun: opts.dryRun ?? false,
       });
-      io.exit(0);
+      // v1.2 #113: 'partial' (codecommit allowlist denied any reply,
+      // or REVIEW_AGENT_FEEDBACK_ALLOWLIST was unset with /feedback
+      // present) → non-zero exit so cron callers can detect a silent
+      // deny without log-scraping. The status downgrade and the
+      // accompanying stderr/stdout context lines are layered inside
+      // recoverFeedbackHistoryCommand.
+      /* v8 ignore next */
+      io.exit(result.status === 'partial' ? 1 : 0);
     });
 
   program.exitOverride();

--- a/packages/db/src/recover-feedback-history.ts
+++ b/packages/db/src/recover-feedback-history.ts
@@ -41,7 +41,25 @@ export type RecoverFeedbackHistoryOpts = {
 };
 
 export type RecoverFeedbackHistoryResult = {
-  readonly status: 'ok';
+  /**
+   * `'ok'`: clean run — every observed `/feedback` reply either resolved
+   * to a candidate or was skipped for a benign reason (unresolved /
+   * orphaned / pre-marker).
+   *
+   * `'partial'` (v1.2 #113): the CLI downgrades to `'partial'` when the
+   * CodeCommit branch surfaces a non-clean recovery — either
+   * `scrape.stats.unauthorized > 0` (the allowlist denied at least one
+   * reply that reached the authz gate), or the operator forgot to set
+   * `REVIEW_AGENT_FEEDBACK_ALLOWLIST` while at least one `/feedback`
+   * command was observed (incomplete cron-time configuration; a future
+   * re-run with the env set could recover authorized replies). The two
+   * arms are independent — the second can fire with `unauthorized === 0`
+   * when every command exited via an earlier gate. Lets cron callers
+   * checking `$?` distinguish "no feedback" from "feedback present but
+   * silently denied or unrecoverable". The helper itself only ever
+   * returns `'ok'`; the downgrade is layered on by the CLI.
+   */
+  readonly status: 'ok' | 'partial';
   readonly candidates: number;
   readonly recovered: number;
   readonly skippedExisting: number;

--- a/packages/platform-codecommit/src/authz.test.ts
+++ b/packages/platform-codecommit/src/authz.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkCodeCommitFeedbackAuthz } from './authz.js';
+
+describe('checkCodeCommitFeedbackAuthz', () => {
+  const ORIGINAL_ENV = process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
+
+  beforeEach(() => {
+    delete process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
+    } else {
+      process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST = ORIGINAL_ENV;
+    }
+  });
+
+  it('denies when allowlistEnv is unset (fail-closed)', () => {
+    const r = checkCodeCommitFeedbackAuthz({ principalId: 'AIDAEXAMPLE' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/fail-closed/);
+  });
+
+  it('denies when allowlistEnv is empty string (fail-closed)', () => {
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: 'AIDAEXAMPLE',
+      allowlistEnv: '',
+    });
+    expect(r.allowed).toBe(false);
+  });
+
+  it('allows when the principal is on the allowlist (single entry)', () => {
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: 'AIDAEXAMPLE',
+      allowlistEnv: 'AIDAEXAMPLE',
+    });
+    expect(r).toEqual({ allowed: true });
+  });
+
+  it('allows when the principal is on the allowlist (CSV with spaces)', () => {
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: 'AIDABOB',
+      allowlistEnv: 'AIDAALICE, AIDABOB ,AIDACAROL',
+    });
+    expect(r).toEqual({ allowed: true });
+  });
+
+  it('denies when the principal is not on the allowlist', () => {
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: 'AIDAEVE',
+      allowlistEnv: 'AIDAALICE,AIDABOB',
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/not on/);
+  });
+
+  it('denies when the principalId is empty (defensive)', () => {
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: '',
+      allowlistEnv: 'AIDAALICE',
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/missing principalId/);
+  });
+
+  it('denies an empty-string principalId even if the allowlist accidentally contains an empty entry', () => {
+    // parseAllowlist strips empty entries, so this exercises the
+    // defensive principalId.length === 0 check at the function head —
+    // belt-and-suspenders against a stub/CLI that could call us with
+    // principalId = '' (e.g. CodeCommit comment with no authorArn).
+    const r = checkCodeCommitFeedbackAuthz({
+      principalId: '',
+      allowlistEnv: ',AIDABOB,', // intentional leading/trailing empties
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/missing principalId/);
+  });
+
+  it('reads from process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST when allowlistEnv is unset', () => {
+    process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST = 'AIDAALICE,AIDABOB';
+    const r = checkCodeCommitFeedbackAuthz({ principalId: 'AIDABOB' });
+    expect(r.allowed).toBe(true);
+  });
+});

--- a/packages/platform-codecommit/src/authz.ts
+++ b/packages/platform-codecommit/src/authz.ts
@@ -1,0 +1,104 @@
+/**
+ * `/feedback` permission guard — v1.2 #95 (introduction), v1.2 #113
+ * (recovery-path coverage).
+ *
+ * `/feedback accept|reject|dismiss` writes into `review_history`,
+ * which the agent re-reads on subsequent reviews as
+ * `<learned_facts>`. An attacker who can drop comments on a PR but
+ * cannot push to the repo therefore has a low-cost path to poison
+ * future review outputs unless we gate the command on **write
+ * permission** to the repository.
+ *
+ *   - **CodeCommit** — there is no equivalent REST endpoint, so we
+ *     start with an operator-managed CSV allowlist in
+ *     `REVIEW_AGENT_FEEDBACK_ALLOWLIST`. Callers come from two
+ *     CodeCommit event sources: the live webhook (SNS-delivered
+ *     CodeCommit comment notifications, where `principalId` is lifted
+ *     from `userIdentity.principalId`) and the CLI recovery walk
+ *     (`review-agent recover feedback-history --platform codecommit`,
+ *     which calls the CodeCommit SDK directly and feeds the reply's
+ *     `authorArn` in as `principalId`). The same allowlist gates
+ *     both paths. Fail closed: empty / unset allowlist denies every
+ *     `/feedback`.
+ *
+ * Denied requests are **silently ignored** by the caller — surfacing
+ * a public rejection comment would create a comment-forward DoS vector
+ * (anyone could trigger an automated reply on every PR by spamming
+ * `/feedback`).
+ *
+ * The reason string returned alongside `allowed: false` is for
+ * structured logs only — never put it back on the PR.
+ */
+
+export type FeedbackAuthzResult = {
+  readonly allowed: boolean;
+  readonly reason?: string;
+};
+
+export type CodeCommitAuthzInput = {
+  /**
+   * The caller's IAM principal. Source depends on the callsite:
+   *   - Live webhook: `userIdentity.principalId` from the SNS-delivered
+   *     CodeCommit comment notification.
+   *   - CLI recovery walk: the reply comment's `authorArn` lifted from
+   *     the CodeCommit SDK response.
+   * An empty / missing principal denies.
+   */
+  readonly principalId: string;
+  /**
+   * Override of the env-derived allowlist. Tests inject this directly;
+   * production reads `REVIEW_AGENT_FEEDBACK_ALLOWLIST` (CSV) when
+   * unset.
+   */
+  readonly allowlistEnv?: string;
+};
+
+/**
+ * Check whether the CodeCommit caller's IAM principal is on the
+ * operator-managed allowlist. Fail-closed: empty / unset
+ * `REVIEW_AGENT_FEEDBACK_ALLOWLIST` denies all `/feedback` regardless
+ * of the principal so a fresh deploy never accepts unsigned writes by
+ * accident.
+ *
+ * Introduced in v1.2 #95 for the live webhook gate; v1.2 #113
+ * extended its use to the disaster-recovery CLI
+ * (`review-agent recover feedback-history --platform codecommit`)
+ * so the recovery walk applies the exact same authz check the live
+ * receiver does.
+ *
+ * The env value is a comma-separated list of full IAM principal
+ * ARNs / IDs. Whitespace around each entry is trimmed.
+ */
+export function checkCodeCommitFeedbackAuthz(input: CodeCommitAuthzInput): FeedbackAuthzResult {
+  const raw =
+    input.allowlistEnv !== undefined
+      ? input.allowlistEnv
+      : typeof process !== 'undefined'
+        ? process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST
+        : undefined;
+  const allowlist = parseAllowlist(raw);
+  if (allowlist.length === 0) {
+    return {
+      allowed: false,
+      reason: 'REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset; CodeCommit /feedback fail-closed',
+    };
+  }
+  if (!input.principalId || input.principalId.length === 0) {
+    return { allowed: false, reason: 'missing principalId on CodeCommit feedback event' };
+  }
+  if (allowlist.includes(input.principalId)) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    reason: `principal '${input.principalId}' is not on REVIEW_AGENT_FEEDBACK_ALLOWLIST`,
+  };
+}
+
+function parseAllowlist(raw: string | undefined): ReadonlyArray<string> {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/packages/platform-codecommit/src/index.ts
+++ b/packages/platform-codecommit/src/index.ts
@@ -9,6 +9,11 @@ export {
   listCodeCommitPullRequestIds,
 } from './adapter.js';
 export {
+  type CodeCommitAuthzInput,
+  checkCodeCommitFeedbackAuthz,
+  type FeedbackAuthzResult,
+} from './authz.js';
+export {
   CODECOMMIT_PLATFORM_ID,
   codecommitPlatform,
 } from './platform.js';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,6 +45,7 @@
     "@opentelemetry/semantic-conventions": "1.28.0",
     "@review-agent/core": "workspace:*",
     "@review-agent/db": "workspace:*",
+    "@review-agent/platform-codecommit": "workspace:*",
     "drizzle-orm": "0.45.2",
     "hono": "4.12.16",
     "zod": "3.25.76"

--- a/packages/server/src/utils/feedback-authz.test.ts
+++ b/packages/server/src/utils/feedback-authz.test.ts
@@ -1,9 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  type CollaboratorPermissionGetter,
-  checkCodeCommitFeedbackAuthz,
-  checkGithubFeedbackAuthz,
-} from './feedback-authz.js';
+import { describe, expect, it, vi } from 'vitest';
+import { type CollaboratorPermissionGetter, checkGithubFeedbackAuthz } from './feedback-authz.js';
 
 function makeOctokit(getter: CollaboratorPermissionGetter) {
   return {
@@ -109,72 +105,5 @@ describe('checkGithubFeedbackAuthz', () => {
   });
 });
 
-describe('checkCodeCommitFeedbackAuthz', () => {
-  const ORIGINAL_ENV = process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
-
-  beforeEach(() => {
-    delete process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
-  });
-
-  afterEach(() => {
-    if (ORIGINAL_ENV === undefined) {
-      delete process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST;
-    } else {
-      process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST = ORIGINAL_ENV;
-    }
-  });
-
-  it('denies when allowlistEnv is unset (fail-closed)', () => {
-    const r = checkCodeCommitFeedbackAuthz({ principalId: 'AIDAEXAMPLE' });
-    expect(r.allowed).toBe(false);
-    expect(r.reason).toMatch(/fail-closed/);
-  });
-
-  it('denies when allowlistEnv is empty string (fail-closed)', () => {
-    const r = checkCodeCommitFeedbackAuthz({
-      principalId: 'AIDAEXAMPLE',
-      allowlistEnv: '',
-    });
-    expect(r.allowed).toBe(false);
-  });
-
-  it('allows when the principal is on the allowlist (single entry)', () => {
-    const r = checkCodeCommitFeedbackAuthz({
-      principalId: 'AIDAEXAMPLE',
-      allowlistEnv: 'AIDAEXAMPLE',
-    });
-    expect(r).toEqual({ allowed: true });
-  });
-
-  it('allows when the principal is on the allowlist (CSV with spaces)', () => {
-    const r = checkCodeCommitFeedbackAuthz({
-      principalId: 'AIDABOB',
-      allowlistEnv: 'AIDAALICE, AIDABOB ,AIDACAROL',
-    });
-    expect(r.allowed).toBe(true);
-  });
-
-  it('denies when the principal is not on the allowlist', () => {
-    const r = checkCodeCommitFeedbackAuthz({
-      principalId: 'AIDAEVE',
-      allowlistEnv: 'AIDAALICE,AIDABOB',
-    });
-    expect(r.allowed).toBe(false);
-    expect(r.reason).toMatch(/not on/);
-  });
-
-  it('denies when the principalId is empty (defensive)', () => {
-    const r = checkCodeCommitFeedbackAuthz({
-      principalId: '',
-      allowlistEnv: 'AIDAALICE',
-    });
-    expect(r.allowed).toBe(false);
-    expect(r.reason).toMatch(/missing principalId/);
-  });
-
-  it('reads from process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST when allowlistEnv is unset', () => {
-    process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST = 'AIDAALICE,AIDABOB';
-    const r = checkCodeCommitFeedbackAuthz({ principalId: 'AIDABOB' });
-    expect(r.allowed).toBe(true);
-  });
-});
+// `checkCodeCommitFeedbackAuthz` lives in `@review-agent/platform-codecommit`
+// (v1.2 #113); its unit tests are in `packages/platform-codecommit/src/authz.test.ts`.

--- a/packages/server/src/utils/feedback-authz.ts
+++ b/packages/server/src/utils/feedback-authz.ts
@@ -30,10 +30,13 @@
  * structured logs only — never put it back on the PR.
  */
 
-export type FeedbackAuthzResult = {
-  readonly allowed: boolean;
-  readonly reason?: string;
-};
+export {
+  type CodeCommitAuthzInput,
+  checkCodeCommitFeedbackAuthz,
+  type FeedbackAuthzResult,
+} from '@review-agent/platform-codecommit';
+
+import type { FeedbackAuthzResult } from '@review-agent/platform-codecommit';
 
 /**
  * Minimal Octokit shape so the server package does not need to
@@ -92,63 +95,4 @@ export async function checkGithubFeedbackAuthz(
     const msg = e instanceof Error ? e.message : 'unknown';
     return { allowed: false, reason: `getCollaboratorPermissionLevel threw: ${msg}` };
   }
-}
-
-export type CodeCommitAuthzInput = {
-  /**
-   * `userIdentity.principalId` (or the adapter-provided equivalent)
-   * from the SNS event. CodeCommit comment notifications expose the
-   * caller's IAM principal here. An empty / missing principal denies.
-   */
-  readonly principalId: string;
-  /**
-   * Override of the env-derived allowlist. Tests inject this directly;
-   * production reads `REVIEW_AGENT_FEEDBACK_ALLOWLIST` (CSV) when
-   * unset.
-   */
-  readonly allowlistEnv?: string;
-};
-
-/**
- * Check whether the CodeCommit caller's IAM principal is on the
- * operator-managed allowlist. Fail-closed: empty / unset
- * `REVIEW_AGENT_FEEDBACK_ALLOWLIST` denies all `/feedback` regardless
- * of the principal so a fresh deploy never accepts unsigned writes by
- * accident.
- *
- * The env value is a comma-separated list of full IAM principal
- * ARNs / IDs. Whitespace around each entry is trimmed.
- */
-export function checkCodeCommitFeedbackAuthz(input: CodeCommitAuthzInput): FeedbackAuthzResult {
-  const raw =
-    input.allowlistEnv !== undefined
-      ? input.allowlistEnv
-      : typeof process !== 'undefined'
-        ? process.env.REVIEW_AGENT_FEEDBACK_ALLOWLIST
-        : undefined;
-  const allowlist = parseAllowlist(raw);
-  if (allowlist.length === 0) {
-    return {
-      allowed: false,
-      reason: 'REVIEW_AGENT_FEEDBACK_ALLOWLIST is unset; CodeCommit /feedback fail-closed',
-    };
-  }
-  if (!input.principalId || input.principalId.length === 0) {
-    return { allowed: false, reason: 'missing principalId on SNS event' };
-  }
-  if (allowlist.includes(input.principalId)) {
-    return { allowed: true };
-  }
-  return {
-    allowed: false,
-    reason: `principal '${input.principalId}' is not on REVIEW_AGENT_FEEDBACK_ALLOWLIST`,
-  };
-}
-
-function parseAllowlist(raw: string | undefined): ReadonlyArray<string> {
-  if (!raw) return [];
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,9 @@ importers:
       '@review-agent/db':
         specifier: workspace:*
         version: link:../db
+      '@review-agent/platform-codecommit':
+        specifier: workspace:*
+        version: link:../platform-codecommit
       drizzle-orm:
         specifier: '>=0.45.2'
         version: 0.45.2(@libsql/client-wasm@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(postgres@3.4.5)


### PR DESCRIPTION
## Summary

- **Security fix**: `review-agent recover feedback-history --platform codecommit` (added in #110) was silently re-promoting runtime-denied `/feedback` replies into `review_history`, defeating the `REVIEW_AGENT_FEEDBACK_ALLOWLIST` gate enforced by the live webhook. Two FP-verifier subagents independently rated this true-positive at 8/10.
- **Fix**: lifted `checkCodeCommitFeedbackAuthz` from `@review-agent/server` to `@review-agent/platform-codecommit` so server (live webhook) and CLI (recovery walk) share one implementation. `scrapeCodeCommitFeedback` now requires `feedbackAllowlist` and rejects replies whose author ARN is not on it (fail-closed on missing `authorArn` and on empty allowlist). New `unauthorized` counter surfaced in the run summary; operator-visible exit signal via `status: 'partial'` → `program.ts` exits 1 so cron callers checking `$?` see a distinct signal.
- **Docs/changeset**: `docs/operations/codecommit-disaster-recovery.md` Step 4.5, `docs/security/feedback-command-authz.md`, spec §8.4, and `.changeset/issue-113-codecommit-recovery-authz.md` updated.

Closes #113

## Test plan

- [x] `pnpm typecheck` green (12 packages)
- [x] `pnpm lint` green (Biome, 423 files)
- [x] `pnpm test:coverage` green; per-package branches: cli 91.12%, platform-codecommit 93.45%, server 90.40% (≥90% threshold)
- [x] `pnpm build` green; `.js` + `.cjs` + `.d.ts` + `.d.cts` produced per package
- [x] Issue #113 acceptance criteria — all 4 mandated test cases present (allow-listed / not-allow-listed / missing-author / unset-allowlist fail-closed)
- [x] Reviewer convergence after 3 rounds (3 + 2 + 1 parallel reviewers; final round zero Critical/High/Medium findings)

## Notes

- OTEL counter (`feedbackRecoveryRejected{reason='unauthorized'}`) is intentionally deferred; the per-run `unauthorized` counter in the CLI summary + non-zero exit code are the operator-visible signals.
- `RecoverFeedbackHistoryResult.status` widened from `'ok'` to `'ok' | 'partial'`; only consumer is this repo's CLI, so no external breakage.