### PR TITLE
feat(dev): pnpm 11.5 migration + make dev-full and local-dev fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24.14.1
@@ -50,7 +50,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/red-team-eval.yml
+++ b/.github/workflows/red-team-eval.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24.14.1
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
       - uses: actions/setup-node@v6
         with:
           node-version: 24.14.1

--- a/.github/workflows/self-review.yml
+++ b/.github/workflows/self-review.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.33.0
+          version: 11.5.0
 
       - uses: actions/setup-node@v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ When the spec and an issue disagree, the spec wins. When the spec is silent,
 - **Language**: TypeScript 5.6.3, ESM-only, strict + `noUncheckedIndexedAccess`
   + `exactOptionalPropertyTypes` + `verbatimModuleSyntax` + NodeNext.
 - **Runtime**: Node.js 24.14.x LTS.
-- **Package manager**: pnpm 10.33.0 workspace monorepo. Lockfile committed.
+- **Package manager**: pnpm 11.5.0 workspace monorepo. Lockfile committed.
 - **Lint + format**: Biome 2.x (single tool, no ESLint, no Prettier).
 - **Test**: Vitest 3.x + v8 coverage. Branches threshold: 90% per package. Lines/functions/statements per-package thresholds vary — see each package's `vitest.config.ts`.
 - **Build**: tsup 8.x — ESM + CJS dual output with `.d.ts` per package.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --virtual .build-deps curl tar \
  && apk del .build-deps
 
 FROM base AS builder
-RUN npm install -g pnpm@10.33.0
+RUN npm install -g pnpm@11.5.0
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json biome.json ./
 COPY packages ./packages
 RUN pnpm install --frozen-lockfile \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 .PHONY: help setup install dev dev-mock dev-web dev-server build typecheck lint test test-coverage clean \
-        db-up db-down db-logs db-migrate dev-stack
+        db-up db-down db-logs db-migrate dev-stack dev-full
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -44,7 +44,7 @@ db-up: ## Start Postgres + ElasticMQ via docker-compose.dev.yml
 	docker compose -f docker-compose.dev.yml up -d
 	@echo "[dev] waiting for Postgres to be healthy..."
 	@until docker compose -f docker-compose.dev.yml ps postgres | grep -q 'healthy'; do sleep 1; done
-	@echo "[dev] Postgres ready at postgresql://review:review@localhost:5432/review_agent"
+	@echo "[dev] Postgres ready at postgresql://review:review@localhost:5435/review_agent"
 
 db-down: ## Stop Postgres + ElasticMQ (keeps data volume)
 	docker compose -f docker-compose.dev.yml down
@@ -53,9 +53,14 @@ db-logs: ## Tail dev Postgres logs
 	docker compose -f docker-compose.dev.yml logs -f postgres
 
 db-migrate: ## Run Drizzle migrations against the dev Postgres
-	DATABASE_URL=postgresql://review:review@localhost:5432/review_agent \
+	DATABASE_URL=postgresql://review:review@localhost:5435/review_agent \
 	  pnpm --filter @review-agent/db db:migrate
 
 dev-stack: ## db-up + dev (web + server) in one shot
 	$(MAKE) db-up
+	$(MAKE) dev
+
+dev-full: ## db-up + db-migrate + dev (web + server) in one shot
+	$(MAKE) db-up
+	$(MAKE) db-migrate
 	$(MAKE) dev

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ For server dev, copy `packages/server/.env.example` to
 so no edits are required to get started:
 
 ```
-DATABASE_URL=postgresql://review:review@localhost:5432/review_agent
+DATABASE_URL=postgresql://review:review@localhost:5435/review_agent
 REVIEW_AGENT_WEBHOOK_SECRET=local-dev-secret
 ```
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: review
       POSTGRES_PASSWORD: review
       POSTGRES_DB: review_agent
-    ports: ["5432:5432"]
+    ports: ["5435:5432"]
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/dev-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -388,7 +388,7 @@ services:
       POSTGRES_USER: review
       POSTGRES_PASSWORD: review
       POSTGRES_DB: review_agent
-    ports: ["5432:5432"]
+    ports: ["5435:5432"]
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/dev-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
@@ -452,7 +452,7 @@ ANTHROPIC_API_KEY=sk-ant-...           # or OPENAI_API_KEY, GOOGLE_GENERATIVE_AI
 REVIEW_AGENT_LANGUAGE=en-US
 
 # --- Backing services -----------------------------------------------------
-DATABASE_URL=postgres://review:review@localhost:5432/review_agent
+DATABASE_URL=postgres://review:review@localhost:5435/review_agent
 QUEUE_URL=http://localhost:9324/000000000000/jobs
 
 # --- GitHub auth ---------------------------------------------------------

--- a/docs/specs/review-agent-spec.md
+++ b/docs/specs/review-agent-spec.md
@@ -56,7 +56,7 @@ Build a self-hostable, OSS, AI code review agent that:
 |---|---|---|
 | Language | TypeScript 5.6+ | Strict mode, ESM only. |
 | Runtime | Node.js 24.15.0 LTS | Supported through 2028-04. Don't add Bun support yet. |
-| Package manager | pnpm 10.x | Workspaces. `packageManager` field pinned. |
+| Package manager | pnpm 11.x | Workspaces. `packageManager` field pinned. |
 | Repo structure | pnpm workspaces monorepo | Single repo, multiple packages. No Turborepo. |
 | Lint + Format | Biome 2.x | Single tool. No ESLint/Prettier. |
 | Test runner | Vitest 2.x | Both unit and integration. |
@@ -509,7 +509,7 @@ pnpm dev                               # all packages in watch mode
 **Native deps required on host:**
 
 - Node.js 24 LTS (we recommend `fnm` or `volta` for version management).
-- pnpm 10.x (`corepack enable`).
+- pnpm 11.x (`corepack enable`).
 - `git` 2.40+ (for sparse-checkout / partial clone).
 - `gitleaks` 8.x — required if running secret-scan code paths locally.
   CONTRIBUTING.md links to install instructions per OS. CI uses the

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.0",
   "engines": {
     "node": ">=24.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,22 +37,5 @@
     "typescript": "5.6.3",
     "vitest": "3.2.4",
     "@vitest/coverage-v8": "3.2.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "drizzle-orm": ">=0.45.2",
-      "@tootallnate/once": ">=3.0.1",
-      "tmp": ">=0.2.4",
-      "fast-xml-parser": ">=5.7.0",
-      "esbuild": ">=0.25.0",
-      "mathjs": ">=15.2.0",
-      "undici": ">=6.24.0",
-      "uuid": ">=14.0.0",
-      "jsondiffpatch": ">=0.7.2",
-      "vite": ">=7.3.2 <8"
-    }
   }
 }

--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   schema: './dist/db/schema/index.js',
   out: './src/db/migrations',
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? 'postgres://review:review@localhost:5432/review_agent',
+    url: process.env.DATABASE_URL ?? 'postgres://review:review@localhost:5435/review_agent',
   },
   verbose: true,
   strict: true,

--- a/packages/core/src/db/migrations/0000_icy_mikhail_rasputin.sql
+++ b/packages/core/src/db/migrations/0000_icy_mikhail_rasputin.sql
@@ -1,4 +1,8 @@
-CREATE ROLE "review_agent_app";--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'review_agent_app') THEN
+		CREATE ROLE "review_agent_app";
+	END IF;
+END $$;--> statement-breakpoint
 CREATE TABLE "audit_log" (
 	"id" bigserial PRIMARY KEY NOT NULL,
 	"ts" timestamp with time zone DEFAULT now() NOT NULL,

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -3,7 +3,7 @@
 
 # Required: Postgres connection string.
 # Matches the docker-compose.dev.yml defaults (`make db-up`).
-DATABASE_URL=postgresql://review:review@localhost:5432/review_agent
+DATABASE_URL=postgresql://review:review@localhost:5435/review_agent
 
 # Optional: bearer token for the /api dashboard namespace.
 # Leave empty to run without auth in local dev (a startup warning is printed).

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "dev": "tsx --env-file=.env.local watch src/dev.ts",
+    "dev": "tsx watch --env-file=.env.local src/dev.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -22,7 +22,7 @@ const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
   process.stderr.write(
     'review-agent [dev]: DATABASE_URL is required for dev. Set it in .env.local or your shell.\n' +
-      '  Example: DATABASE_URL=postgres://review@localhost:5432/review_agent_dev\n',
+      '  Example: DATABASE_URL=postgres://review@localhost:5435/review_agent_dev\n',
   );
   process.exit(1);
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,11 @@
 packages:
   - "packages/*"
 
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true
+  "@playwright/browser-chromium": false
+  better-sqlite3: false
+  protobufjs: false
 
 overrides:
   drizzle-orm: ">=0.45.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,17 @@
 packages:
   - "packages/*"
+
+onlyBuiltDependencies:
+  - esbuild
+
+overrides:
+  drizzle-orm: ">=0.45.2"
+  "@tootallnate/once": ">=3.0.1"
+  tmp: ">=0.2.4"
+  fast-xml-parser: ">=5.7.0"
+  esbuild: ">=0.25.0"
+  mathjs: ">=15.2.0"
+  undici: ">=6.24.0"
+  uuid: ">=14.0.0"
+  jsondiffpatch: ">=0.7.2"
+  vite: ">=7.3.2 <8"


### PR DESCRIPTION
## Summary
Completes the pnpm 10→11 migration and adds a one-command local dev
workflow, with the fixes needed to make `make dev-full` run end-to-end.

## Commits
- fix(pnpm): move overrides + onlyBuiltDependencies to pnpm-workspace.yaml
- chore(pnpm): bump pinned pnpm to 11.5.0 (CI / Dockerfile / docs)
- fix(pnpm): adopt `allowBuilds` (pnpm 11 dropped onlyBuiltDependencies);
  esbuild built, playwright-chromium / better-sqlite3 / protobufjs denied
- fix(db): guard 0000 `CREATE ROLE review_agent_app` with `DO $$ IF NOT EXISTS`
  (dev-init.sql pre-creates it → 42710); role attrs & RLS unchanged
- fix(server): reorder dev script to `tsx watch --env-file=… src/dev.ts`
- feat(make): add `dev-full` (db-up → db-migrate → dev); move dev Postgres
  host port 5432→5435 (host mapping only; creds/container port unchanged)

## Verification
- `make dev-full` boots end-to-end: Postgres healthy on 5435, migrations
  applied, web (:5173) + server (:8080) up.
- Security review of the diff: no findings (pins preserved, build-script
  approval tightened, static SQL).

## Notes
- Lockfile unchanged (pnpm 10/11 share lockfileVersion 9.0).
